### PR TITLE
[COOK-2625] PowerDNS Recursor has a different process name pattern than its service name

### DIFF
--- a/recipes/recursor.rb
+++ b/recipes/recursor.rb
@@ -20,6 +20,7 @@
 package "pdns-recursor"
 
 service "pdns-recursor" do
+  pattern "pdns_recursor"
   action [:enable, :start]
 end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2625
