### PR TITLE
Add following properties: baseurl/gpgkey/debug_baseurl (CentOS only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Installs PowerDNS recursor 4.X series using PowerDNS official repository in the 
 
 - `version`: Which version is installed, defaults to the latest version available in the repository.
 - `debug`: (CentOS only), installs debug-symbols from PowerDNS debug repository.
+- `baseurl`: (CentOS only), set the PowerDNS repository URL (Default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40')
+- `gpgkey`: (CentOS only), set the PowerDNS repository gpg key URL (Default: 'https://repo.powerdns.com/FD380FBB-pub.asc')
+- `baseurl_debug`: (CentOS only), set the PowerDNS debug repository URL (Default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug')
 
 #### Usage Example
 

--- a/resources/pdns_recursor_install_rhel.rb
+++ b/resources/pdns_recursor_install_rhel.rb
@@ -26,6 +26,9 @@ end
 property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
+property :baseurl, String, default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
+property :gpgkey, String, default: 'https://repo.powerdns.com/FD380FBB-pub.asc'
+property :baseurl_debug, [String, nil], default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
 
 action :install do
 
@@ -37,19 +40,21 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-rec-40' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  repository_version = new_resource.baseurl.split('/').last
+
+  yum_repository "powerdns-#{repository_version}" do
+    description "PowerDNS repository for PowerDNS Recursor - #{repository_version}"
+    baseurl new_resource.baseurl
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-rec-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  yum_repository "powerdns-#{repository_version}-debuginfo" do
+    description "PowerDNS repository for PowerDNS Recursor - #{repository_version} debug symbols"
+    baseurl new_resource.baseurl_debug
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create


### PR DESCRIPTION
- STATE -
Currently, the way the custom resource "pdns_recursor_install" is created does not
allow to change the PowerDNS yum repository (in case we mirror PowerDNS)

- FIX -
Add 3 new properties:
- baseurl: to set PowerDNS repository URL
- gpgkey: to set PowerDNS repository gpg key
- baseurl_debug: to set PowerDNS debug repository URL

This PR is related to https://github.com/dnsimple/chef-pdns/issues/50