### PR TITLE
Add following properties: baseurl/gpgkey/debug_baseurl (CentOS only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Installs PowerDNS authoritative server 4.X series using PowerDNS official reposi
 | instance_name | String      | name_property  | Yes|
 | version       | String, nil | nil            | No |
 | debug         | true, false | false          | No |
+| baseurl (CentOS only) | String      | http://repo.powerdns.com/centos/$basearch/$releasever/rec-40 | No |
+| gpgkeys (CentOS only) | String      |  https://repo.powerdns.com/FD380FBB-pub.asc | No |
+| baseurl_debug (CentOS only) | String | http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug | No |
 
 #### Usage example
 
@@ -207,6 +210,10 @@ Please review [PowerDNS documentation section](https://doc.powerdns.com/) to und
 |----------------|------------|-----------------|-------------|
 | instance_name  | String     | name_property   | No |
 | version        | String, nil| nil             | No |
+| debug         | true, false | false          | No |
+| baseurl (CentOS only) | String      | http://repo.powerdns.com/centos/$basearch/$releasever/auth-40 | No |
+| gpgkeys (CentOS only) | String      |  https://repo.powerdns.com/CBC8B383-pub.asc | No |
+| baseurl_debug (CentOS only) | String | http://repo.powerdns.com/centos/$basearch/$releasever/auth-40/debug | No |
 
 #### Usage Example
 

--- a/resources/pdns_authoritative_install_rhel.rb
+++ b/resources/pdns_authoritative_install_rhel.rb
@@ -26,6 +26,9 @@ end
 property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
+property :baseurl, String, default: 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40'
+property :gpgkey, String, default: 'https://repo.powerdns.com/CBC8B383-pub.asc'
+property :baseurl_debug, String, default: 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40/debug'
 
 action :install do
   yum_package 'epel-release' do
@@ -33,19 +36,21 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-auth-40' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  repository_version = new_resource.baseurl.split('/').last
+
+  yum_repository "powerdns-#{repository_version}" do
+    description "PowerDNS repository for PowerDNS Authoritative - #{repository_version}"
+    baseurl new_resource.baseurl
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-auth-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40/debug'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  yum_repository "powerdns-#{repository_version}-debuginfo" do
+    description "PowerDNS repository for PowerDNS Authoritative - #{repository_version} debug symbols"
+    baseurl new_resource.baseurl_debug
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create

--- a/resources/pdns_recursor_install_rhel.rb
+++ b/resources/pdns_recursor_install_rhel.rb
@@ -26,6 +26,9 @@ end
 property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
+property :baseurl, String, default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
+property :gpgkey, String, default: 'https://repo.powerdns.com/FD380FBB-pub.asc'
+property :baseurl_debug, [String, nil], default: 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
 
 action :install do
 
@@ -37,19 +40,21 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-rec-40' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  repository_version = new_resource.baseurl.split('/').last
+
+  yum_repository "powerdns-#{repository_version}" do
+    description "PowerDNS repository for PowerDNS Recursor - #{repository_version}"
+    baseurl new_resource.baseurl
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-rec-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
-    gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
+  yum_repository "powerdns-#{repository_version}-debuginfo" do
+    description "PowerDNS repository for PowerDNS Recursor - #{repository_version} debug symbols"
+    baseurl new_resource.baseurl_debug
+    gpgkey new_resource.gpgkey
     priority '90'
     includepkgs 'pdns*'
     action :create


### PR DESCRIPTION
- STATE
Currently, pdns_authoritative_install_rhel/pdns_recursor_install_rhel
don't provide a way to overwrite the yum repositories 'baseurl' and
'gpgkey'.

- FIX
Add 3 new properties:
  - baseurl: to set PowerDNS repository URL
  - gpgkey: to set PowerDNS repository gpgkey
  - baseurl_debug: to set PowerDNS debug repository URL

Change-Id: I4a38ba8364448f7a1afe14de5bcc88022672cd5d

This PR is related to https://github.com/dnsimple/chef-pdns/issues/50