### PR TITLE
Fix naming schema for init scripts

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,13 +21,19 @@ suites:
       - recipe[pdns_test::inspec_dependencies]
       - recipe[pdns_test::recursor_install_multi]
     attributes:
-  - name: authoritative-postgres
-    run_list:
-      - recipe[pdns_test::inspec_dependencies]
-      - recipe[pdns_test::authoritative_install_single_postgres]
-    attributes:
   - name: authoritative-multi
     run_list:
       - recipe[pdns_test::inspec_dependencies]
       - recipe[pdns_test::authoritative_install_multi]
+    attributes:
+  - name: authoritative-postgres
+    includes: [
+      'centos-7',
+      'debian-8',
+      'ubuntu-14.04',
+      'ubuntu-16.04'
+    ]
+    run_list:
+      - recipe[pdns_test::inspec_dependencies]
+      - recipe[pdns_test::authoritative_install_single_postgres]
     attributes:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ To (> 3.3.0): `template "/etc/init.d/pdns-authoritative_#{new_resource.instance_
 One way of fixing this is to add to your recipe a block of code similar to the one below this lines, this will delete the outdated configuration files.
 
 ```
-service 'pdns-authoritative-<your-resource-name>' do
-  action :disable
+execute 'service pdns-authoritative-<your-resource-name> stop' do
+  action :run
+  only_if { ::File.exists? '/etc/init.d/pdns-authoritative-<your-resource-name>' }
+end
+
+execute '/usr/sbin/update-rc.d -f pdns-authoritative-<your-resource-name> remove' do
+  action :run
+  only_if { ::File.exists? '/etc/init.d/pdns-authoritative-<your-resource-name>' }
 end
 
 file 'pdns-authoritative-<your-resource-name>.conf' do
@@ -83,8 +89,14 @@ To (> 3.3.0): `template "/etc/init.d/pdns-recursor_#{new_resource.instance_name}
 For the recursor it's the same, you'll need to add something like this to your recipe:
 
 ```
-service 'pdns_recursor-<your-resource-name>' do
-  action :disable
+execute 'service pdns_recursor-<your-resource-name> stop' do
+  action :run
+  only_if { ::File.exists? '/etc/init.d/pdns_recursor-<your-resource-name>' }
+end
+
+execute '/usr/sbin/update-rc.d -f pdns_recursor-<your-resource-name> remove' do
+  action :run
+  only_if { ::File.exists? '/etc/init.d/pdns_recursor-<your-resource-name>' }
 end
 
 file '/etc/init.d/pdns_recursor-<your-resource-name>' dp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The current version of the cookbook provides basic support for recursors and aut
 | Debian   | bind, postgresql | SysVinit     |
 | CentOS   | bind, postgresql | SysVinit     |
 
+
 ### Platforms:
 
 * Ubuntu (14.04)
@@ -81,7 +82,7 @@ For advanced use it is recommended to take a look at the chef resources themselv
 PowerDNS uses hyphens `-` in their configuration files, chef resources and ruby symbols don't work very well with hyphens, so using underscore `_` in this cookbook for properties is required and will be tranlated automatically to hyphens in the configuration templates, example:
 
 ```
-pdns_authoritative_config 'server-01' do
+pdns_authoritative_config 'server_01' do
   action :create
   launch ['gpgsql']
   variables(
@@ -94,7 +95,7 @@ pdns_authoritative_config 'server-01' do
 end
 ```
 
-Will create a file named `/etc/powerdns/pdns-authoritative-server-01.conf`:
+Will create a file named `/etc/powerdns/pdns-authoritative_server_01.conf`:
 
 ```
 launch ['gpgsql']
@@ -128,7 +129,7 @@ Installs PowerDNS authoritative server 4.X series using PowerDNS official reposi
 Install a PowerDNS authoritative server package named `server-01` with the latest version available in the repository.
 
 ```
-pdns_authoritative_install 'server-01' do
+pdns_authoritative_install 'server_01' do
   action :install
 end
 ```
@@ -160,7 +161,7 @@ Creates a PowerDNS recursor configuration, there is a fixed set of required prop
 Create a PowerDNS authoritative configuration file named `server-01`:
 
 ```
-pdns_authoritative_config 'server-01' do
+pdns_authoritative_config 'server_01' do
   action :create
   launch ['gpgsql']
   variables(
@@ -195,7 +196,7 @@ Creates a init service to manage a PowerDNS authoritative instance. This service
 #### Usage example
 
 ```
-pdns_authoritative_service 'server-01' do
+pdns_authoritative_service 'server_01' do
   action [:enable, :start]
 end
 ```
@@ -236,9 +237,9 @@ Installs PowerDNS recursor 4.X series using PowerDNS official repository in the 
 
 #### Usage Example
 
-Install a 4. powerdns instance named 'my-recursor' on ubuntu 14.04:
+Install a 4. powerdns instance named 'my_recursor' on ubuntu 14.04:
 
-    pdns_recursor_install 'my-recursor' do
+    pdns_recursor_install 'my_recursor' do
       version '4.0.4-1pdns.trusty'
     end
 
@@ -266,9 +267,9 @@ Sets up a PowerDNS recursor instance using the appropiate init system .
 
 #### Usage Example
 
-Configure a PowerDNS recursor service instance named 'my-recursor' in your wrapper cookbook for Acme Corp with a custom template named `my-recursor.erb`
+Configure a PowerDNS recursor service instance named 'my_recursor' in your wrapper cookbook for Acme Corp with a custom template named `my-recursor.erb`
 
-    pdns_recursor_service 'my-recursor' do
+    pdns_recursor_service 'my_recursor' do
       source 'my-recursor.erb'
       cookbook 'acme-pdns-recursor'
     end
@@ -307,13 +308,21 @@ Creates a PowerDNS recursor configuration.
 
 #### Usage Example
 
-Create a PowerDNS recursor configuration named 'my-recursor' in your wrapper cookbook for Acme Corp which uses a custom template named `my-recursor.erb` and a few attributes:
+Create a PowerDNS recursor configuration named 'my_recursor' in your wrapper cookbook for Acme Corp which uses a custom template named `my-recursor.erb` and a few attributes:
 
-    pdns_recursor_config 'my-recursor' do
+    pdns_recursor_config 'my_recursor' do
       source 'my-recursor.erb'
       cookbook 'acme-pdns-recursor'
       variables(client-tcp-timeout: '20', loglevel: '5', network-timeout: '2000')
     end
+
+#### Virtual Hosting
+
+PowerDNS supports virtual hosting: running many instances of PowerDNS on different ports on the same machine. This is done by a few clever hacks on the init scripts that allow to specify different config files for each instance. This cookbook leverages this functionality in both recursor and authoritative.
+
+[PowerDNS recommends a specific naming schema](https://doc.powerdns.com/md/authoritative/running/) authoritative for virtual hosting. Specifically it does not allow hyphens (-) on the init scripts beyond the first which is provided by the init script (`/etc/init.d/pdns-`).
+
+We have adopted the convention of using underscores (_) in the name attributes of underscores in order to comply with this requirement.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,73 @@ The current version of the cookbook provides basic support for recursors and aut
 | Debian   | bind, postgresql | SysVinit     |
 | CentOS   | bind, postgresql | SysVinit     |
 
+IMPORTANT:
+
+Versions 3.0 to 3.2 of this cookbook has used a different naming schema for init scripts and config files.
+
+In order to conform with PowerDNS specifications for its [virtual hosting](#virtual-hosting) features, we have changed the way of naming init scripts and config files. PowerDNS advices not to use hyphens `-` on init scripts, after their own prefixes (which uses hyphens).
+
+If you are upgrading from one of those versions here are some recomendations to migrate to newer versions.
+
+- Authoritative:
+
+What has changed inside the resources:
+
+Services declaration change on (3.0.0 to 3.2.0) from: `service 'pdns-authoritative-<your-resource-name>' do`
+To (> 3.3.0): `service "pdns-authoritative_#{new_resource.instance_name}" do`
+
+Configuration files change on (3.0.0 to 3.2.0) from: `template "pdns-authoritative-#{new_resource.instance_name}.conf" do`
+To (> 3.3.0): `template "pdns-authoritative_#{new_resource.instance_name}.conf" do `
+
+Init scripts change on (3.0.0 to 3.2.0) from: `template "/etc/init.d/pdns-authoritative-#{new_resource.instance_name}" do`
+To (> 3.3.0): `template "/etc/init.d/pdns-authoritative_#{new_resource.instance_name}" do`
+
+One way of fixing this is to add to your recipe a block of code similar to the one below this lines, this will delete the outdated configuration files.
+
+```
+service 'pdns-authoritative-<your-resource-name>' do
+  action :disable
+end
+
+file 'pdns-authoritative-<your-resource-name>.conf' do
+  action :delete
+end
+
+file '/etc/init.d/pdns-authoritative-<your-resource-name>' do
+  action :delete
+end
+```
+
+- Recursor
+
+What has changed inside the resources:
+
+Services declaration change on (3.0.0 to 3.2.0) from: `service 'pdns-recursor-<your-resource-name>' do`
+To (> 3.3.0): `service "pdns-recursor_#{new_resource.instance_name}" do`
+
+Init scripts change on (3.0.0 to 3.2.0) from: `template "/etc/init.d/pdns-recursor-#{new_resource.instance_name}" do`
+To (> 3.3.0): `template "/etc/init.d/pdns-recursor_#{new_resource.instance_name}" do`
+
+For the recursor it's the same, you'll need to add something like this to your recipe:
+
+```
+service 'pdns_recursor-<your-resource-name>' do
+  action :disable
+end
+
+file '/etc/init.d/pdns_recursor-<your-resource-name>' dp
+  action :delete
+end
+```
+
+- Final Note
+
+If you decide to follow the convention recommended by PDNS for Virtual Hosting, and you want to change the hyphens used for underscore, you'll need to additionally delete or rename some configuration files as you would normally do when changing the name on a chef resource.
 
 ### Platforms:
 
-* Ubuntu (14.04)
-* CentOS (6.8)
+- Ubuntu (14.04)
+- CentOS (6.8)
 
 ### Chef:
 
@@ -50,12 +112,12 @@ Only `SysVinit` is supported for "pdns-authoritative".
 
 ### Required Cookbooks:
 
-* apt
-* yum
+- apt
+- yum
 
 ### Suggested Cookbooks:
 
-* postgres (for the PostgreSQL backend)
+- postgres (for the PostgreSQL backend)
 
 ## Usage
 
@@ -254,7 +316,7 @@ Sets up a PowerDNS recursor instance using the appropiate init system .
 
 | Name           | Class      |  Default value                                        | Consistent? |
 |----------------|------------|-------------------------------------------------------|-------------|
-| instance_name  | String     | name_property                                         | Yes         |  
+| instance_name  | String     | name_property                                         | Yes         |
 | config_dir     | String     | see `default_recursor_config_directory` helper method | Yes         |
 | cookbook (SysVinit)      | String,nil | 'pdns'                                                | No          |
 | source  (SysVinit)       | String,nil | 'recursor.init.#{node['platform_family']}.erb'                            | No          |

--- a/libraries/recursor_helpers.rb
+++ b/libraries/recursor_helpers.rb
@@ -23,7 +23,7 @@ module PdnsRecursorResource
     end
 
     def sysvinit_name(name = nil)
-      "pdns_recursor-#{name}"
+      "pdns-recursor_#{name}"
     end
 
     def default_recursor_config_directory

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@dnsimple.com'
 license          'Apache 2.0'
 description      'Installs/Configures PowerDNS Recursor and Authoritative server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.0'
+version          '3.3.0'
 source_url       'https://github.com/dnsimple/chef-pdns'
 issues_url       'https://github.com/dnsimple/chef-pdns/issues'
 

--- a/resources/pdns_authoritative_config.rb
+++ b/resources/pdns_authoritative_config.rb
@@ -76,7 +76,7 @@ action :create do
     action :create
   end
 
-  template "#{new_resource.config_dir}/pdns-authoritative-#{new_resource.instance_name}.conf" do
+  template "#{new_resource.config_dir}/pdns-authoritative_#{new_resource.instance_name}.conf" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'

--- a/resources/pdns_authoritative_service_debian_sysvinit.rb
+++ b/resources/pdns_authoritative_service_debian_sysvinit.rb
@@ -41,20 +41,20 @@ action :enable do
     action [:stop, :disable]
   end
 
-  template "/etc/init.d/pdns-authoritative-#{new_resource.instance_name}" do
+  template "/etc/init.d/pdns-authoritative_#{new_resource.instance_name}" do
     source new_resource.source
     owner 'root'
     group 'root'
     mode '0755'
     variables(
       socket_dir: new_resource.socket_dir,
-      provides: "pdns-authoritative-#{new_resource.instance_name}"
+      provides: "pdns-authoritative_#{new_resource.instance_name}"
       )
     cookbook new_resource.cookbook
     action :create
   end
 
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Debian
     pattern 'pdns_server'
     supports restart: true, status: true
@@ -63,7 +63,7 @@ action :enable do
 end
 
 action :start do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Debian
     pattern 'pdns_server'
     supports restart: true, status: true
@@ -72,7 +72,7 @@ action :start do
 end
 
 action :stop do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Debian
     pattern 'pdns_server'
     supports restart: true, status: true
@@ -81,7 +81,7 @@ action :stop do
 end
 
 action :restart do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Debian
     pattern 'pdns_server'
     supports restart: true, status: true

--- a/resources/pdns_authoritative_service_rhel_sysvinit.rb
+++ b/resources/pdns_authoritative_service_rhel_sysvinit.rb
@@ -78,7 +78,7 @@ action :stop do
 end
 
 action :restart do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Redhat
     pattern 'pdns_server'
     supports restart: true, status: true

--- a/resources/pdns_authoritative_service_rhel_sysvinit.rb
+++ b/resources/pdns_authoritative_service_rhel_sysvinit.rb
@@ -38,19 +38,20 @@ action :enable do
     action [:stop, :disable]
   end
 
-  template "/etc/init.d/pdns-authoritative-#{new_resource.instance_name}" do
+  template "/etc/init.d/pdns-authoritative_#{new_resource.instance_name}" do
     source new_resource.source
     owner 'root'
     group 'root'
     mode '0755'
     variables(
-      socket_dir: new_resource.socket_dir
+      socket_dir: new_resource.socket_dir,
+      provides: "pdns-authoritative_#{new_resource.instance_name}"
       )
     cookbook new_resource.cookbook
     action :create
   end
 
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Redhat
     pattern 'pdns_server'
     supports restart: true, status: true
@@ -59,7 +60,7 @@ action :enable do
 end
 
 action :start do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Redhat
     pattern 'pdns_server'
     supports restart: true, status: true
@@ -68,7 +69,7 @@ action :start do
 end
 
 action :stop do
-  service "pdns-authoritative-#{new_resource.instance_name}" do
+  service "pdns-authoritative_#{new_resource.instance_name}" do
     provider Chef::Provider::Service::Init::Redhat
     pattern 'pdns_server'
     supports restart: true, status: true

--- a/resources/pdns_recursor_service_sysvinit.rb
+++ b/resources/pdns_recursor_service_sysvinit.rb
@@ -21,9 +21,16 @@ include ::PdnsRecursorResource::Helpers
 
 resource_name :pdns_recursor_service_sysvinit
 
-provides :pdns_recursor_service, os: 'linux' do |_node|
-  Chef::Platform::ServiceHelpers.service_resource_providers.include?(:debian) ||
-    Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
+provides :pdns_recursor_service, platform: 'centos' do |node| # ~FC005
+  node['platform_version'].to_i >= 6
+end
+
+provides :pdns_recursor_service, platform: 'ubuntu' do |node|
+  node['platform_version'].to_f >= 14.04
+end
+
+provides :pdns_recursor_service, platform: 'debian' do |node|
+  node['platform_version'].to_i >= 8
 end
 
 property :instance_name, String, name_property: true

--- a/resources/pdns_recursor_service_sysvinit.rb
+++ b/resources/pdns_recursor_service_sysvinit.rb
@@ -63,7 +63,6 @@ action :enable do
     supports restart: true, status: true
     action :enable
   end
-
 end
 
 action :start do

--- a/spec/unit/recipes/authoritative_debian_spec.rb
+++ b/spec/unit/recipes/authoritative_debian_spec.rb
@@ -36,12 +36,12 @@ describe 'pdns_test::authoritative_install_multi' do
     #
 
     it 'creates a specific init script' do
-      expect(chef_run).to create_template('/etc/init.d/pdns-authoritative-server-01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-authoritative_server_01')
     end
 
     it 'enables and starts pdns_authoritative service' do
-      expect(chef_run).to enable_service('pdns-authoritative-server-01').with(pattern: 'pdns_server')
-      expect(chef_run).to start_service('pdns-authoritative-server-01').with(pattern: 'pdns_server')
+      expect(chef_run).to enable_service('pdns-authoritative_server_01').with(pattern: 'pdns_server')
+      expect(chef_run).to start_service('pdns-authoritative_server_01').with(pattern: 'pdns_server')
     end
 
     #
@@ -64,7 +64,7 @@ describe 'pdns_test::authoritative_install_multi' do
     end
 
     it 'creates a authoritative instance config' do
-      expect(chef_run).to create_template('/etc/powerdns/pdns-authoritative-server-01.conf')
+      expect(chef_run).to create_template('/etc/powerdns/pdns-authoritative_server_01.conf')
       .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/authoritative_rhel_spec.rb
+++ b/spec/unit/recipes/authoritative_rhel_spec.rb
@@ -39,12 +39,12 @@ describe 'pdns_test::authoritative_install_multi' do
     #
 
     it 'creates a specific init script' do
-      expect(chef_run).to create_template('/etc/init.d/pdns-authoritative-server-01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-authoritative_server_01')
     end
 
     it 'enables and starts pdns_authoritative service' do
-      expect(chef_run).to enable_service('pdns-authoritative-server-01').with(pattern: 'pdns_server')
-      expect(chef_run).to start_service('pdns-authoritative-server-01').with(pattern: 'pdns_server')
+      expect(chef_run).to enable_service('pdns-authoritative_server_01').with(pattern: 'pdns_server')
+      expect(chef_run).to start_service('pdns-authoritative_server_01').with(pattern: 'pdns_server')
     end
 
     #
@@ -67,7 +67,7 @@ describe 'pdns_test::authoritative_install_multi' do
     end
 
     it 'creates a authoritative instance config' do
-      expect(chef_run).to create_template('/etc/pdns/pdns-authoritative-server-01.conf')
+      expect(chef_run).to create_template('/etc/pdns/pdns-authoritative_server_01.conf')
       .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/recursor_debian_spec.rb
+++ b/spec/unit/recipes/recursor_debian_spec.rb
@@ -37,18 +37,18 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{debian upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns-recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
       mock_service_resource_providers(%i{debian upstart})
-      expect(chef_run).to enable_service('pdns_recursor-server_01')
-      expect(chef_run).to start_service('pdns_recursor-server_01')
+      expect(chef_run).to enable_service('pdns-recursor_server_01')
+      expect(chef_run).to start_service('pdns-recursor_server_01')
     end
 
     it 'should not creates any specific init script (Systemd)' do
       mock_service_resource_providers(%i{systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor-server_01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do

--- a/spec/unit/recipes/recursor_debian_spec.rb
+++ b/spec/unit/recipes/recursor_debian_spec.rb
@@ -10,7 +10,7 @@ describe 'pdns_test::recursor_install_multi' do
     end
 
     let(:chef_run) { ubuntu_runner.converge(described_recipe) }
-    let(:version) { '4.0.4-1pdns.trusty' }
+    let(:version) { '4.0.5-1pdns.trusty' }
 
     #
     # Tests for the install resource

--- a/spec/unit/recipes/recursor_debian_spec.rb
+++ b/spec/unit/recipes/recursor_debian_spec.rb
@@ -37,18 +37,18 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{debian upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server-01')
+      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
       mock_service_resource_providers(%i{debian upstart})
-      expect(chef_run).to enable_service('pdns_recursor-server-01')
-      expect(chef_run).to start_service('pdns_recursor-server-01')
+      expect(chef_run).to enable_service('pdns_recursor-server_01')
+      expect(chef_run).to start_service('pdns_recursor-server_01')
     end
 
     it 'should not creates any specific init script (Systemd)' do
       mock_service_resource_providers(%i{systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server-01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do
@@ -76,11 +76,11 @@ describe 'pdns_test::recursor_install_multi' do
     end
 
     it 'creates a pdns recursor socket directory' do
-      expect(chef_run).to create_directory('/var/run/server-01')
+      expect(chef_run).to create_directory('/var/run/server_01')
     end
 
     it 'creates a recursor instance' do
-      expect(chef_run).to create_template('/etc/powerdns/recursor-server-01.conf')
+      expect(chef_run).to create_template('/etc/powerdns/recursor-server_01.conf')
       .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/recursor_debian_spec.rb
+++ b/spec/unit/recipes/recursor_debian_spec.rb
@@ -37,7 +37,7 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{debian upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
@@ -48,13 +48,13 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'should not creates any specific init script (Systemd)' do
       mock_service_resource_providers(%i{systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do
       mock_service_resource_providers(%i{systemd})
-      expect(chef_run).to enable_service('pdns-recursor@server-01')
-      expect(chef_run).to start_service('pdns-recursor@server-01')
+      expect(chef_run).to enable_service('pdns-recursor@server_01')
+      expect(chef_run).to start_service('pdns-recursor@server_01')
     end
     #
     # Tests for the config resource

--- a/spec/unit/recipes/recursor_rhel_spec.rb
+++ b/spec/unit/recipes/recursor_rhel_spec.rb
@@ -40,18 +40,18 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server-01')
+      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to enable_service('pdns_recursor-server-01')
-      expect(chef_run).to start_service('pdns_recursor-server-01')
+      expect(chef_run).to enable_service('pdns_recursor-server_01')
+      expect(chef_run).to start_service('pdns_recursor-server_01')
     end
 
     it 'should not creates a specific init script (Systemd)' do
       mock_service_resource_providers(%i{redhat systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server-01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do
@@ -80,11 +80,11 @@ describe 'pdns_test::recursor_install_multi' do
     end
 
     it 'creates a pdns recursor socket directory' do
-      expect(chef_run).to create_directory('/var/run/server-01')
+      expect(chef_run).to create_directory('/var/run/server_01')
     end
 
     it 'creates a recursor instance config' do
-      expect(chef_run).to create_template('/etc/pdns-recursor/recursor-server-01.conf')
+      expect(chef_run).to create_template('/etc/pdns-recursor/recursor-server_01.conf')
       .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/recursor_rhel_spec.rb
+++ b/spec/unit/recipes/recursor_rhel_spec.rb
@@ -40,24 +40,24 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to enable_service('pdns_recursor-server_01')
-      expect(chef_run).to start_service('pdns_recursor-server_01')
+      expect(chef_run).to enable_service('pdns-recursor-server_01')
+      expect(chef_run).to start_service('pdns-recursor-server_01')
     end
 
     it 'should not creates a specific init script (Systemd)' do
       mock_service_resource_providers(%i{redhat systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor-server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do
       mock_service_resource_providers(%i{redhat systemd})
-      expect(chef_run).to enable_service('pdns-recursor@server-01')
-      expect(chef_run).to start_service('pdns-recursor@server-01')
+      expect(chef_run).to enable_service('pdns-recursor@server_01')
+      expect(chef_run).to start_service('pdns-recursor@server_01')
     end
 
     #

--- a/spec/unit/recipes/recursor_rhel_spec.rb
+++ b/spec/unit/recipes/recursor_rhel_spec.rb
@@ -12,7 +12,7 @@ describe 'pdns_test::recursor_install_multi' do
     end
 
     let(:chef_run) { rhel_runner.converge(described_recipe) }
-    let(:version) { '4.0.4-1pdns.el6' }
+    let(:version) { '4.0.5-1pdns.el6' }
 
     #
     # Tests for the install resource

--- a/spec/unit/recipes/recursor_rhel_spec.rb
+++ b/spec/unit/recipes/recursor_rhel_spec.rb
@@ -40,18 +40,18 @@ describe 'pdns_test::recursor_install_multi' do
 
     it 'creates a specific init script (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to create_template('/etc/init.d/pdns-recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it 'enables and starts pdns_recursor service (SysVinit)' do
       mock_service_resource_providers(%i{redhat upstart})
-      expect(chef_run).to enable_service('pdns-recursor-server_01')
-      expect(chef_run).to start_service('pdns-recursor-server_01')
+      expect(chef_run).to enable_service('pdns-recursor_server_01')
+      expect(chef_run).to start_service('pdns-recursor_server_01')
     end
 
     it 'should not creates a specific init script (Systemd)' do
       mock_service_resource_providers(%i{redhat systemd})
-      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor-server_01')
+      expect(chef_run).not_to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it 'enables and starts pdns_recursor instance (Systemd)' do

--- a/templates/default/authoritative.init.rhel.erb
+++ b/templates/default/authoritative.init.rhel.erb
@@ -3,7 +3,7 @@
 # description: PDNS is a versatile high performance authoritative nameserver
 
 ### BEGIN INIT INFO
-# Provides:          pdns
+# Provides:          <%= @provides %>
 # Required-Start:    $remote_fs $network $syslog
 # Required-Stop:     $remote_fs $network $syslog
 # Should-Start:

--- a/templates/default/recursor.init.debian.erb
+++ b/templates/default/recursor.init.debian.erb
@@ -25,7 +25,7 @@ DESC="PowerDNS recursor"
 NAME=pdns_recursor
 INSTANCE_NAME=<%= @pdns_virtual_instance %>
 DAEMON=/usr/sbin/$NAME
-CONFIG_FILE=<%= ::File.join(@config_dir, "#{@service_name}.conf") %>
+CONFIG_FILE=<%= ::File.join(@config_dir, "recursor-#{@pdns_virtual_instance}.conf") %>
 CONFIG_DIR=<%= @config_dir %>
 
 # Derive the socket-dir setting from $CONFIG_FILE
@@ -34,7 +34,7 @@ PIDDIR=$(awk -F= '/^socket-dir=/ {print $2}' $CONFIG_FILE)
 if [ -z "$PIDDIR" ]; then PIDDIR=/var/run; fi
   # The binary "pdns_recursor" handles its own pidfile according the following
   # schema: pdns_recursor-<VIRTUAL_INSTANCE_NAME>
-  PIDFILE=<%= ::File.join('$PIDDIR', @pdns_virtual_instance, "#{@service_name}.pid") %>
+  PIDFILE="${PIDDIR}/pdns_recursor-${INSTANCE_NAME}.pid"
 
 # Gracefully exit if the package has been removed.
 test -x $DAEMON || exit 0

--- a/test/cookbooks/pdns_test/libraries/helpers.rb
+++ b/test/cookbooks/pdns_test/libraries/helpers.rb
@@ -1,11 +1,11 @@
 def recursor_version_per_platform
   case node['platform']
   when 'debian'
-    '4.0.4-1pdns.jessie'
+    '4.0.5-1pdns.jessie'
   when 'ubuntu'
-    "4.0.4-1pdns.#{node['lsb']['codename']}"
+    "4.0.5-1pdns.#{node['lsb']['codename']}"
   when 'centos'
-    "4.0.4-1pdns.el#{node['packages']['centos-release']['version']}"
+    "4.0.5-1pdns.el#{node['packages']['centos-release']['version']}"
   end
 end
 

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -1,26 +1,26 @@
-pdns_authoritative_install 'server-01' do
+pdns_authoritative_install 'server_01' do
   action :install
   version authoritative_version_per_platform
 end
 
-pdns_authoritative_service 'server-01' do
+pdns_authoritative_service 'server_01' do
   action :enable
 end
 
-pdns_authoritative_config 'server-01' do
+pdns_authoritative_config 'server_01' do
   action :create
 end
 
-pdns_authoritative_install 'server-02' do
+pdns_authoritative_install 'server_02' do
   action :install
   version authoritative_version_per_platform
 end
 
-pdns_authoritative_service 'server-02' do
+pdns_authoritative_service 'server_02' do
   action :enable
 end
 
-pdns_authoritative_config 'server-02' do
+pdns_authoritative_config 'server_02' do
   action :create
   run_user 'another-pdns'
   run_group 'another-pdns'
@@ -54,10 +54,10 @@ file "#{default_authoritative_config_directory}/example.org.zone" do
   mode '0750'
 end
 
-pdns_authoritative_service 'server-01' do
+pdns_authoritative_service 'server_01' do
   action :start
 end
 
-pdns_authoritative_service 'server-02' do
+pdns_authoritative_service 'server_02' do
   action :start
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -1,13 +1,13 @@
-pdns_authoritative_install 'server-01' do
+pdns_authoritative_install 'server_01' do
   action :install
   version authoritative_version_per_platform
 end
 
-pdns_authoritative_service 'server-01' do
+pdns_authoritative_service 'server_01' do
   action :enable
 end
 
-pdns_authoritative_config 'server-01' do
+pdns_authoritative_config 'server_01' do
   action :create
   launch ['gpgsql']
   variables(
@@ -52,14 +52,14 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-add_zone = 'pdnsutil --config-name authoritative-server-01 create-zone example.org ns1.example.org && pdnsutil  --config-name authoritative-server-01 add-record example.org smoke A 127.0.0.123'
+add_zone = 'pdnsutil --config-name authoritative_server_01 create-zone example.org ns1.example.org && pdnsutil  --config-name authoritative_server_01 add-record example.org smoke A 127.0.0.123'
 
 execute add_zone do
   user 'root'
-  not_if 'pdnsutil --config-name authoritative-server-01 list-zone example.org | grep example.org'
+  not_if 'pdnsutil --config-name authoritative_server_01 list-zone example.org | grep example.org'
   action :run
 end
 
-pdns_authoritative_service 'server-01' do
+pdns_authoritative_service 'server_01' do
   action :restart
 end

--- a/test/cookbooks/pdns_test/recipes/recursor_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/recursor_install_multi.rb
@@ -1,22 +1,22 @@
-pdns_recursor_install 'server-01' do
+pdns_recursor_install 'server_01' do
   action :install
   version recursor_version_per_platform
 end
 
-pdns_recursor_config 'server-01' do
+pdns_recursor_config 'server_01' do
   action :create
 end
 
-pdns_recursor_service 'server-01' do
+pdns_recursor_service 'server_01' do
   action [:enable, :start]
 end
 
-pdns_recursor_install 'server-02' do
+pdns_recursor_install 'server_02' do
   action :install
   version recursor_version_per_platform
 end
 
-pdns_recursor_config 'server-02' do
+pdns_recursor_config 'server_02' do
   action :create
   run_user 'another-pdns'
   run_group 'another-pdns'
@@ -26,6 +26,6 @@ pdns_recursor_config 'server-02' do
   )
 end
 
-pdns_recursor_service 'server-02' do
+pdns_recursor_service 'server_02' do
   action [:enable, :start]
 end

--- a/test/integration/authoritative-multi/default_spec.rb
+++ b/test/integration/authoritative-multi/default_spec.rb
@@ -22,11 +22,11 @@ describe group(default_authoritative_run_user) do
   it { should exist }
 end
 
-describe processes('pdns_server-authoritative-server-01-instance') do
+describe processes('pdns_server-authoritative_server_01-instance') do
   its ('users') { should eq [default_authoritative_run_user] }
 end
 
-describe processes('pdns_server-authoritative-server-02-instance') do
+describe processes('pdns_server-authoritative_server_02-instance') do
   its ('users') { should eq ['another-pdns'] }
 end
 

--- a/test/integration/authoritative-postgres/default_spec.rb
+++ b/test/integration/authoritative-postgres/default_spec.rb
@@ -21,7 +21,7 @@ describe group(default_authoritative_run_user) do
   it { should exist }
 end
 
-describe processes('pdns_server-authoritative-server-01-instance') do
+describe processes('pdns_server-authoritative_server_01-instance') do
   its ('users') { should eq [default_authoritative_run_user] }
 end
 

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -27,11 +27,11 @@ describe processes('pdns_recursor') do
 end
 
 describe command('dig -p 53 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Recursor 4.0.4/) }
+  its('stdout.chomp') { should match(/"PowerDNS Recursor 4.0.5/) }
 end
 
 describe command('dig -p 54 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Recursor 4.0.4/) }
+  its('stdout.chomp') { should match(/"PowerDNS Recursor 4.0.5/) }
 end
 
 describe command('dig -p 53 @127.0.0.1 dnsimple.com') do
@@ -41,4 +41,3 @@ end
 describe command('dig -p 54 @127.0.0.1 dnsimple.com') do
   its('stdout') { should match(/208.93.64.253/) }
 end
-


### PR DESCRIPTION
The version 3.00 and further versions of this cookbook did not name consistently different elements created by the resources: init scripts and configuration files in particular. 

PowerDNS supports a feature called virtual hosts that allows to have several PowerDNS servers running on the same machine by just creating a symlink (or copying) the init script with the condition that a particular naming schema is used: PDNS-NAME, given that beyond that first hyphen there is no more hyphens since this will cause troubles with the init script. See doc: https://doc.powerdns.com/md/authoritative/running/

This PR adopts that schema for both authoritative and recursor, effectively standardising the way init scripts are named. 

Example, the following code:

```ruby
pdns_authoritative_service 'server_01' do
  action :create
end
```

Will create an init script named: `/etc/init.d/pdns-authoritative_server_01`

And the follwoing code:

```ruby
pdns_recursor_service 'server_01' do
  action :create
end
```

Will create an init script named: `/etc/init.d/pdns-recursor_server_01`


