### PR TITLE
Stopping default recursor on debian based distros for sysvinit

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -47,4 +47,3 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools lsof dnsutils -y
-

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,9 +11,9 @@ verifier:
 platforms:
   - name: ubuntu-16.04
   - name: ubuntu-14.04
-  - name: debian-8
-  - name: centos-6
-  - name: centos-7
+  - name: debian-8.7
+  - name: centos-6.7
+  - name: centos-7.2
 
 suites:
   - name: recursor-multi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.4.1 / 2017-06-28
+
+## Bug Fixes
+
+* Stopping the default recursor on `pdns_recursor_service` for sysvinit.
+  Fixes: https://github.com/dnsimple/chef-pdns/issues/77
+
 # 3.4.0 / 2017-06-27
 
 ## Maintenance

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@dnsimple.com'
 license          'Apache 2.0'
 description      'Installs/Configures PowerDNS Recursor and Authoritative server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.4.0'
+version          '3.4.1'
 source_url       'https://github.com/dnsimple/chef-pdns'
 issues_url       'https://github.com/dnsimple/chef-pdns/issues'
 

--- a/resources/pdns_recursor_service_sysvinit.rb
+++ b/resources/pdns_recursor_service_sysvinit.rb
@@ -45,6 +45,7 @@ action :enable do
   # Some distros start pdns-recursor after installing it, we want to stop it
   # The behavior of the init script on CentOS 6 causes a bug so we skip it there
   # (see https://github.com/dnsimple/chef-pdns/issues/77#issuecomment-311644973)
+
   service 'pdns-recursor' do
     supports restart: true, status: true
     action :stop

--- a/resources/pdns_recursor_service_sysvinit.rb
+++ b/resources/pdns_recursor_service_sysvinit.rb
@@ -52,7 +52,7 @@ action :enable do
 
   service 'pdns-recursor' do
     supports restart: true, status: true
-    action pdns_default_actions
+    action pdns_recursor_actions
   end
 
   service_name = sysvinit_name(new_resource.instance_name)

--- a/resources/pdns_recursor_service_sysvinit.rb
+++ b/resources/pdns_recursor_service_sysvinit.rb
@@ -45,16 +45,14 @@ action :enable do
   # Some distros start pdns-recursor after installing it, we want to stop it
   # The behavior of the init script on CentOS 6 causes a bug so we skip it there
   # (see https://github.com/dnsimple/chef-pdns/issues/77#issuecomment-311644973)
-  service 'pdns-recursor' do
-    supports restart: true, status: true
-    action :stop
-    only_if { node['platform_family'] == 'debian' }
-  end
-
   # We want to prevent the default recursor to start on boot
+
+  pdns_recursor_actions = [:disable]
+  pdns_recursor_actions = pdns_recursor_actions.unshift(:stop) if node['platform_family'] == 'debian'
+
   service 'pdns-recursor' do
     supports restart: true, status: true
-    action :disable
+    action pdns_default_actions
   end
 
   service_name = sysvinit_name(new_resource.instance_name)


### PR DESCRIPTION
This PR fixes #77 by solution proposed in the latest comment, (see issue for complete discussion of the bug).

The solution is stopping the default recursor instance only on debian based distros for sysvinit provider.

This has been proved to pass tests in both Vagrant and Docker.