### PR TITLE
Revert naming scheme for sysvinit

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,7 +38,7 @@ module Pdns
     end
 
     def sysvinit_name(name = nil)
-      "pdns_recursor-#{name}"
+      "pdns-recursor_#{name}"
     end
 
     def default_recursor_run_user
@@ -69,7 +69,7 @@ module Pdns
     end
 
     def sysvinit_name(name = nil)
-      "pdns_authoritative-#{name}"
+      "pdns-authoritative_#{name}"
     end
 
     def default_authoritative_run_user

--- a/resources/pdns_authoritative_config.rb
+++ b/resources/pdns_authoritative_config.rb
@@ -79,7 +79,7 @@ action :create do
     action :create
   end
 
-  template "#{new_resource.config_dir}/pdns-#{new_resource.instance_name}.conf" do
+  template "#{new_resource.config_dir}/pdns-authoritative_#{new_resource.instance_name}.conf" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'

--- a/resources/pdns_authoritative_config.rb
+++ b/resources/pdns_authoritative_config.rb
@@ -84,7 +84,7 @@ action :create do
     cookbook new_resource.cookbook
     owner 'root'
     group 'root'
-    mode '0640'
+    mode '0440'
     variables(
       launch: new_resource.launch,
       socket_dir: new_resource.socket_dir,

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe Pdns::PdnsAuthoritativeHelpers do
+  subject do
+    class DummyClass < Chef::Node
+      include Pdns::PdnsAuthoritativeHelpers
+    end
+    DummyClass.new
+  end
+
+  describe '#systemd_name' do
+    context 'when no unique name has been given' do
+      let(:name) { nil }
+      it 'returns the service name without a unique name' do
+        expect(subject.systemd_name(name)).to eq 'pdns@'
+      end
+    end
+
+    context 'when a name has been given' do
+      let(:name) { 'test' }
+      it 'returns the service name with a unique name' do
+        expect(subject.systemd_name(name)).to eq 'pdns@test'
+      end
+    end
+  end
+
+  describe '#sysvinit_name' do
+    context 'when no unique name has been given' do
+      let(:name) { nil }
+      it 'returns the service name without a unique name' do
+        expect(subject.sysvinit_name(name)).to eq 'pdns-authoritative_'
+      end
+    end
+
+    context 'when a name has been given' do
+      let(:name) { 'test' }
+      it 'returns the service name with a unique name' do
+        expect(subject.sysvinit_name(name)).to eq 'pdns-authoritative_test'
+      end
+    end
+  end
+end
+
+RSpec.describe Pdns::PdnsRecursorHelpers do
+  subject do
+    class DummyClass < Chef::Node
+      include Pdns::PdnsRecursorHelpers
+    end
+    DummyClass.new
+  end
+
+  describe '#systemd_name' do
+    context 'when no unique name has been given' do
+      let(:name) { nil }
+      it 'returns the service name without a unique name' do
+        expect(subject.systemd_name(name)).to eq 'pdns-recursor@'
+      end
+    end
+
+    context 'when a name has been given' do
+      let(:name) { 'test' }
+      it 'returns the service name with a unique name' do
+        expect(subject.systemd_name(name)).to eq 'pdns-recursor@test'
+      end
+    end
+  end
+
+  describe '#sysvinit_name' do
+    context 'when no unique name has been given' do
+      let(:name) { nil }
+      it 'returns the service name without a unique name' do
+        expect(subject.sysvinit_name(name)).to eq 'pdns-recursor_'
+      end
+    end
+
+    context 'when a name has been given' do
+      let(:name) { 'test' }
+      it 'returns the service name with a unique name' do
+        expect(subject.sysvinit_name(name)).to eq 'pdns-recursor_test'
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,3 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
-
-RSpec.configure {}
-
-at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/authoritative_debian_spec.rb
+++ b/spec/unit/recipes/authoritative_debian_spec.rb
@@ -65,7 +65,7 @@ describe 'pdns_test::authoritative_install_multi' do
 
     it 'creates a authoritative instance config' do
       expect(chef_run).to create_template('/etc/powerdns/pdns-authoritative_server_01.conf')
-        .with(owner: 'root', group: 'root', mode: '0640')
+        .with(owner: 'root', group: 'root', mode: '0440')
     end
 
     it 'converges successfully' do

--- a/spec/unit/recipes/authoritative_debian_spec.rb
+++ b/spec/unit/recipes/authoritative_debian_spec.rb
@@ -36,12 +36,12 @@ describe 'pdns_test::authoritative_install_multi' do
     #
 
     it '[sysvinit] creates a specific init script' do
-      expect(chef_run).to create_link('/etc/init.d/pdns_authoritative-server_01').with(to: 'pdns')
+      expect(chef_run).to create_link('/etc/init.d/pdns-authoritative_server_01').with(to: 'pdns')
     end
 
     it '[sysvinit] enables and starts pdns_authoritative service' do
-      expect(chef_run).to enable_service('pdns_authoritative-server_01')
-      expect(chef_run).to start_service('pdns_authoritative-server_01')
+      expect(chef_run).to enable_service('pdns-authoritative_server_01')
+      expect(chef_run).to start_service('pdns-authoritative_server_01')
     end
 
     #
@@ -64,7 +64,7 @@ describe 'pdns_test::authoritative_install_multi' do
     end
 
     it 'creates a authoritative instance config' do
-      expect(chef_run).to create_template('/etc/powerdns/pdns-server_01.conf')
+      expect(chef_run).to create_template('/etc/powerdns/pdns-authoritative_server_01.conf')
         .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/authoritative_rhel_spec.rb
+++ b/spec/unit/recipes/authoritative_rhel_spec.rb
@@ -64,7 +64,7 @@ describe 'pdns_test::authoritative_install_multi' do
 
     it 'creates a authoritative instance config' do
       expect(chef_run).to create_template('/etc/pdns/pdns-authoritative_server_01.conf')
-        .with(owner: 'root', group: 'root', mode: '0640')
+        .with(owner: 'root', group: 'root', mode: '0440')
     end
 
     it 'converges successfully' do

--- a/spec/unit/recipes/authoritative_rhel_spec.rb
+++ b/spec/unit/recipes/authoritative_rhel_spec.rb
@@ -39,8 +39,8 @@ describe 'pdns_test::authoritative_install_multi' do
     #
 
     it '[sysvinit] enables and starts pdns_authoritative service' do
-      expect(chef_run).to enable_service('pdns_authoritative-server_01')
-      expect(chef_run).to start_service('pdns_authoritative-server_01')
+      expect(chef_run).to enable_service('pdns-authoritative_server_01')
+      expect(chef_run).to start_service('pdns-authoritative_server_01')
     end
 
     #
@@ -63,7 +63,7 @@ describe 'pdns_test::authoritative_install_multi' do
     end
 
     it 'creates a authoritative instance config' do
-      expect(chef_run).to create_template('/etc/pdns/pdns-server_01.conf')
+      expect(chef_run).to create_template('/etc/pdns/pdns-authoritative_server_01.conf')
         .with(owner: 'root', group: 'root', mode: '0640')
     end
 

--- a/spec/unit/recipes/recursor_debian_spec.rb
+++ b/spec/unit/recipes/recursor_debian_spec.rb
@@ -36,12 +36,12 @@ describe 'pdns_test::recursor_install_multi' do
     #
 
     it '[sysvinit] creates a specific init script' do
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it '[sysvinit] enables and starts pdns_recursor service' do
-      expect(chef_run).to enable_service('pdns_recursor-server_01')
-      expect(chef_run).to start_service('pdns_recursor-server_01')
+      expect(chef_run).to enable_service('pdns-recursor_server_01')
+      expect(chef_run).to start_service('pdns-recursor_server_01')
     end
 
     #

--- a/spec/unit/recipes/recursor_rhel_spec.rb
+++ b/spec/unit/recipes/recursor_rhel_spec.rb
@@ -39,12 +39,12 @@ describe 'pdns_test::recursor_install_multi' do
     #
 
     it '[sysvinit] creates a specific init script' do
-      expect(chef_run).to create_template('/etc/init.d/pdns_recursor-server_01')
+      expect(chef_run).to create_template('/etc/init.d/pdns-recursor_server_01')
     end
 
     it '[sysvinit] enables and starts pdns_recursor service' do
-      expect(chef_run).to enable_service('pdns_recursor-server_01')
-      expect(chef_run).to start_service('pdns_recursor-server_01')
+      expect(chef_run).to enable_service('pdns-recursor_server_01')
+      expect(chef_run).to start_service('pdns-recursor_server_01')
     end
 
     #

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -4,20 +4,12 @@ pdns_authoritative_install 'server_01' do
   action :install
 end
 
-pdns_authoritative_service 'server_01' do
-  action :enable
-end
-
 pdns_authoritative_config 'server_01' do
   action :create
 end
 
 pdns_authoritative_install 'server_02' do
   action :install
-end
-
-pdns_authoritative_service 'server_02' do
-  action :enable
 end
 
 pdns_authoritative_config 'server_02' do
@@ -62,9 +54,9 @@ file "#{config_dir}/example.org.zone" do
 end
 
 pdns_authoritative_service 'server_01' do
-  action :start
+  action [:enable, :start]
 end
 
 pdns_authoritative_service 'server_02' do
-  action :start
+  action [:enable, :start]
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -1,3 +1,5 @@
+config_dir = ::Pdns::PdnsAuthoritativeHelpers.default_authoritative_config_directory(node['platform_family'])
+
 pdns_authoritative_install 'server_01' do
   action :install
 end
@@ -24,11 +26,11 @@ pdns_authoritative_config 'server_02' do
   run_group 'another-pdns'
   run_user_home '/var/lib/another-pdns'
   variables(
-    'local-port' => '54'
+    'local-port' => '54',
+    'bind_config' => "#{config_dir}/bindbackend.conf"
   )
 end
 
-config_dir = ::Pdns::PdnsAuthoritativeHelpers.default_authoritative_config_directory(node['platform_family'])
 test_zonefile = <<-EOF
 zone "example.org" { type master; file "#{config_dir}/example.org.zone"; };
 EOF

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -31,6 +31,12 @@ pdns_authoritative_config 'server_02' do
   )
 end
 
+group 'pdns' do
+  action :modify
+  members 'another-pdns'
+  append true
+end
+
 test_zonefile = <<-EOF
 zone "example.org" { type master; file "#{config_dir}/example.org.zone"; };
 EOF

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -48,7 +48,7 @@ end
 execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   user 'postgres'
   action :run
-  not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
+  not_if 'psql -t -d pdns -c "SELECT \'public.domains\'::regclass;"', user: 'postgres'
 end
 
 add_zone = 'pdnsutil --config-name server_01 create-zone example.org ns1.example.org && pdnsutil  --config-name server_01 add-record example.org smoke A 127.0.0.123'

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -51,10 +51,10 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "SELECT \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-add_zone = 'pdnsutil --config-name server_01 create-zone example.org ns1.example.org && pdnsutil  --config-name server_01 add-record example.org smoke A 127.0.0.123'
+add_zone = 'pdnsutil --config-name authoritative_server_01 create-zone example.org ns1.example.org && pdnsutil --config-name authoritative_server_01 add-record example.org smoke A 127.0.0.123'
 
 execute add_zone do
   user 'root'
-  not_if 'pdnsutil --config-name server_01 list-zone example.org | grep example.org'
+  not_if 'pdnsutil --config-name authoritative_server_01 list-zone example.org | grep example.org'
   action :run
 end

--- a/test/integration/authoritative-postgres/default_spec.rb
+++ b/test/integration/authoritative-postgres/default_spec.rb
@@ -28,5 +28,5 @@ describe command('dig chaos txt version.bind @127.0.0.1 +short') do
 end
 
 describe command('dig @127.0.0.1 smoke.example.org') do
-  its('stdout.chomp') { should match(/127.0.0.123/) }
+  its('stdout.chomp') { should match(/127\.0\.0\.123/) }
 end


### PR DESCRIPTION
#66 created a regression with already deployed powerdns services which were named differently. This reverts them back to #69.