### PR TITLE
Rename default recursor configuration

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -69,7 +69,7 @@ module Pdns
 
     def recursor_instance_config(name = '')
       if name.empty?
-        'pdns-recursor.conf'
+        'recursor.conf'
       else
         "recursor-#{name}.conf"
       end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Pdns::RecursorHelpers do
     context 'without a name' do
       let(:instance) { '' }
       it 'returns the default configuration' do
-        expect(subject.recursor_instance_config(instance)).to eq 'pdns-recursor.conf'
+        expect(subject.recursor_instance_config(instance)).to eq 'recursor.conf'
       end
     end
 


### PR DESCRIPTION
I came upon a regression with how we name the recursor configuration file. We should not be prefixing it with `pdns-` because according to the documentation the default is `recursor.conf` and when a [config name](https://doc.powerdns.com/md/recursor/settings/#config-name) is provided, then it will use `recursor-{name}.conf` instead.