### PR TITLE
Fix config permissions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13
+  product_name: chef
+  product_version: 13
   # On CentOS 6, restart the 'postgres' database could fail the first time so
   # let's try twice before failing:
   # https://github.com/sous-chefs/postgresql/issues/421

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -76,7 +76,7 @@ action :create do
   directory new_resource.config_dir do
     owner 'root'
     group new_resource.run_group
-    mode '0750'
+    mode '0755'
     action :create
   end
 

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -48,13 +48,6 @@ property :cookbook, String, default: 'pdns'
 property :variables, Hash, default: lazy { |resource| { bind_config: "#{resource.config_dir}/bindbackend.conf" } }
 
 action :create do
-  directory new_resource.config_dir do
-    owner 'root'
-    group 'root'
-    mode '0755'
-    action :create
-  end
-
   user new_resource.run_user do
     home new_resource.run_user_home
     shell new_resource.run_user_shell
@@ -80,11 +73,18 @@ action :create do
     action :create
   end
 
+  directory new_resource.config_dir do
+    owner 'root'
+    group new_resource.run_group
+    mode '0750'
+    action :create
+  end
+
   template "#{new_resource.config_dir}/#{authoritative_instance_config(new_resource.instance_name)}" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'
-    group 'root'
+    group new_resource.run_group
     mode '0640'
     variables(
       launch: new_resource.launch,

--- a/resources/recursor_config.rb
+++ b/resources/recursor_config.rb
@@ -75,7 +75,7 @@ action :create do
   directory new_resource.config_dir do
     owner 'root'
     group new_resource.run_group
-    mode '0750'
+    mode '0755'
     action :create
   end
 

--- a/resources/recursor_config.rb
+++ b/resources/recursor_config.rb
@@ -47,13 +47,6 @@ property :cookbook, String, default: 'pdns'
 property :variables, Hash, default: {}
 
 action :create do
-  directory new_resource.config_dir do
-    owner 'root'
-    group 'root'
-    mode '0755'
-    action :create
-  end
-
   user new_resource.run_user do
     home new_resource.run_user_home
     shell new_resource.run_user_shell
@@ -79,11 +72,18 @@ action :create do
     action :create
   end
 
+  directory new_resource.config_dir do
+    owner 'root'
+    group new_resource.run_group
+    mode '0750'
+    action :create
+  end
+
   template "#{new_resource.config_dir}/#{recursor_instance_config(new_resource.instance_name)}" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'
-    group 'root'
+    group new_resource.run_group
     mode '0640'
     variables(
       socket_dir: new_resource.socket_dir,

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -48,7 +48,7 @@ end
 
 ## Regression test for https://github.com/dnsimple/chef-pdns/issues/89
 describe command('rec_control --config-name=server_02 --socket-dir=/var/run/server_02 reload-zones') do
-  its('stdout') { should_not match('unable to parse configuration file')}
+  its('stdout') { should_not match('unable to parse configuration file') }
   its('stdout') { should_not match('Encountered error reloading zones, keeping original data: Unable to re-parse configuration file') }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -45,3 +45,10 @@ end
 describe command('dig -p 54 @127.0.0.1 dnsimple.com') do
   its('stdout') { should match(Regexp.new(/\d+\.\d+\.\d+\.\d+/)) }
 end
+
+## Regression test for https://github.com/dnsimple/chef-pdns/issues/89
+describe command('rec_control --config-name=server_02 --socket-dir=/var/run/server_02 reload-zones') do
+  its('stdout') { should_not match('unable to parse configuration file')}
+  its('stdout') { should_not match('Encountered error reloading zones, keeping original data: Unable to re-parse configuration file') }
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -48,6 +48,7 @@ end
 
 ## Regression test for https://github.com/dnsimple/chef-pdns/issues/89
 describe command('rec_control --config-name=server_02 --socket-dir=/var/run/server_02 reload-zones') do
+  its('stdout') { should match('ok') }
   its('stdout') { should_not match('unable to parse configuration file') }
   its('stdout') { should_not match('Encountered error reloading zones, keeping original data: Unable to re-parse configuration file') }
   its('exit_status') { should eq 0 }


### PR DESCRIPTION
The default permissions were too strict. We didn't want the config files writeable by PowerDNS because it's not necessary for operation, but they need to be readable x.x

This PR splits the difference by not making the files world readable but making them the group set by the resource.

This might be a touch too far, and we may want to 644 and make the user and group that set the resource.

Feedback welcome.

Fixes: #89 