### PR TITLE
Invert logic for recursor service

### DIFF
--- a/resources/recursor_service_systemd.rb
+++ b/resources/recursor_service_systemd.rb
@@ -33,7 +33,7 @@ action :enable do
   service 'pdns-recursor' do
     supports restart: true, status: true
     action [:disable, :stop]
-    only_if { new_resource.instance_name.empty? }
+    not_if { new_resource.instance_name.empty? }
   end
 
   service systemd_name(new_resource.instance_name) do


### PR DESCRIPTION
This is to prevent it from attempting to re-signal the default instance in systemd if you explicitly configure it without an instance name. The `systemd_name` helper takes into account the default name so it ends up signaling a disable, stop, then a enable, start.