### PR TITLE
Upgrade to Chef 13+ and Re-Factor Instances

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -34,13 +34,13 @@ platforms:
           - RUN /usr/bin/apt-get update
           - RUN /usr/bin/apt-get install dnsutils -y
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-          - RUN /usr/bin/apt-get update
-          - RUN /usr/bin/apt-get install dnsutils -y
+  # - name: ubuntu-18.04
+  #   driver:
+  #     image: dokken/ubuntu-18.04
+  #     pid_one_command: /bin/systemd
+  #     intermediate_instructions:
+  #         - RUN /usr/bin/apt-get update
+  #         - RUN /usr/bin/apt-get install dnsutils -y
 
   - name: centos-6
     driver:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -33,20 +33,24 @@ platforms:
       intermediate_instructions:
           - RUN /usr/bin/apt-get update
           - RUN /usr/bin/apt-get install dnsutils -y
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+          - RUN /usr/bin/apt-get update
+          - RUN /usr/bin/apt-get install dnsutils -y
 
   - name: centos-6
     driver:
       image: dokken/centos-6
+      pid_one_command: /sbin/init
 
   - name: centos-7
     driver:
       image: dokken/centos-7
-      platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
   - name: debian-8
     driver:
@@ -55,5 +59,3 @@ platforms:
       intermediate_instructions:
           - RUN /usr/bin/apt-get update
           - RUN /usr/bin/apt-get install dnsutils -y
-    volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,7 @@ verifier:
   name: inspec
 
 platforms:
+  - name: ubuntu-18.04
   - name: ubuntu-16.04
   - name: ubuntu-14.04
   - name: debian-8.8

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Provides resources for installing and configuring both PowerDNS authoritative an
 
 [![Build Status](https://travis-ci.org/dnsimple/chef-pdns.svg?branch=master)](https://travis-ci.org/dnsimple/chef-pdns)
 
-## Requirements
+## Deprecation Warning:
 
-IMPORTANT: Please read the Deprecations and Compatibility Notes sections below since there are breaking changes between versions 2 and 3 of this cookbook.
+The 5.x series of this cookbook now requires Chef 13 or newer which removes the dependency on the apt cookbook. We have also removed the 'instance_name' property from the install resources as they were never used and only affect the configuration and service resources.
+
+By default now, we will install the latest stable release of PowerDNS via loose version constraints. This was the behavior before, but because of how they name the package repositories, we had to start defaulting to a series release. A new 'series' property in the install resources now correspond to the major and minor version number combined. Currently this is '41' which is the 4.1.x series of releases in PowerDNS.
+
+## Requirements
 
 ### Platforms:
 
@@ -87,7 +91,6 @@ And a service named `pdns-server_01` which is symbolically linked linked to `pdn
 Most properties are simple ruby strings, but there is another cases that require special attention.
 Properties specified as elements in arrays will be split up (see split ruby method) and separated by commas.
 Boolean properties will be always translated to 'yes' or 'no'.
-Some properties need to be set consistently accross resources, they will be noted in their specific sections at the top under 'Consistent?'.
 Most of the properties are optional and have sane defaults, so they are only recommended for customized installs.
 
 ### pdns_authoritative_install
@@ -96,18 +99,27 @@ Installs PowerDNS authoritative server 4.X series using PowerDNS official reposi
 
 #### Properties
 
-| Name          | Class       |  Default value | Consistent?|
-|---------------|-------------|----------------|------------|
-| instance_name | String      | name_property  | Yes|
-| version       | String, nil | nil            | No |
-| debug         | true, false | false          | No |
+| Name          | Type        |  Default value |
+|---------------|-------------|----------------|
+| version       | String      | ''             |
+| series        | String      | '41'           |
+| debug         | true, false | false          |
 
-#### Usage example
+#### Usage examples
 
 Install a PowerDNS authoritative server package named `server-01` with the latest version available in the repository.
 
-```
+```ruby
 pdns_authoritative_install 'server_01' do
+  action :install
+end
+```
+
+Install the latest stable 4.0.x version of the Authoritative Nameserver
+
+```ruby
+pdns_authoritative_install 'older_stable' do
+  series '40'
   action :install
 end
 ```
@@ -120,7 +132,7 @@ Creates a PowerDNS recursor configuration, there is a fixed set of required prop
 
 | Name           | Class      |  Default value  | Consistent? |
 |----------------|------------|-----------------|-------------|
-| instance_name  | String     | name_property   | Yes         |
+| instance_name  | String     | resource name   | Yes         |
 | launch         | Array, nil | ['bind']        | No          |
 | config_dir     | String     | see `default_authoritative_config_directory` helper method | Yes |
 | socket_dir     | String     | "/var/run/#{resource.instance_name}" | Yes |
@@ -186,18 +198,21 @@ Installs PowerDNS recursor 4.X series using PowerDNS official repository in the 
 
 #### Properties
 
-| Name           | Class       |  Default value  | Consistent? |
-|----------------|-------------|-----------------|-------------|
-| version        | String      | name_property   | Yes         |
-| debug          | True, False | String, nil     | No          |
+| Name           | Type        |  Default value  |
+|----------------|-------------|-----------------|
+| version        | String      | ''              |
+| series         | String      | '41'            |
+| debug          | true, false | false           |
 
 #### Usage Example
 
-Install a 4. powerdns instance named 'my_recursor' on ubuntu 14.04:
+Install the latest 4.0.x release PowerDNS recursor.
 
-    pdns_recursor_install 'my_recursor' do
-      version '4.0.4-1pdns.trusty'
-    end
+```ruby
+pdns_recursor_install 'my_recursor' do
+  series '40'
+end
+```
 
 ### pdns_recursor_service
 
@@ -225,10 +240,12 @@ Sets up a PowerDNS recursor instance using the appropiate init system .
 
 Configure a PowerDNS recursor service instance named 'my_recursor' in your wrapper cookbook for Acme Corp with a custom template named `my-recursor.erb`
 
-    pdns_recursor_service 'my_recursor' do
-      source 'my-recursor.erb'
-      cookbook 'acme-pdns-recursor'
-    end
+```ruby
+pdns_recursor_service 'my_recursor' do
+  source 'my-recursor.erb'
+  cookbook 'acme-pdns-recursor'
+end
+```
 
 ### pdns_recursor_config
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ There is an specific file for testing guidelines on this cokbook: TESTING.md
 License & Authors
 -----------------
 - Author:: Aaron Kalin (<aaron.kalin@dnsimple.com>)
-- Author:: Jacobo García (<jacobo.garcia@dnsimple.com>)
+- Author:: Amy Aronsohn (<amy.aronsohn@dnsimple.com>)
 - Author:: Anthony Eden (<anthony.eden@dnsimple.com>)
 
 ```text

--- a/README.md
+++ b/README.md
@@ -10,40 +10,6 @@ Provides resources for installing and configuring both PowerDNS authoritative an
 
 IMPORTANT: Please read the Deprecations and Compatibility Notes sections below since there are breaking changes between versions 2 and 3 of this cookbook.
 
-### Deprecations
-
-  - The recipe and attribute based way of setting different PowerDNS installs is completely deprecated, there are no  attributes in the newest version of this cookbok neither recipes to add to the run list.
-  - `pdnsrecord` and `domainrecord` resources have been deprecated since they were coupled with sqlite3 backend.
-  - Ubuntu 12.02 support has been removed, if you want this platform to be supported PRs are welcome, see the CONTRIBUTING.md file.
-
-### 4.x Compatibility Notes
-
-Users of the previous versions of the cookbook may find a few breaking changes. Here are the highlights:
-
-#### Chef 12.14 or newer
-
-To help clear up additional code and remove the 'yum' cookbook dependency, we have jumped up to Chef 12.14 as the minimum version. We'll look into the potential options of removing the 'apt' cookbook dependency as well.
-
-#### pdns_authoritative_backend has been removed
-
-This resource has been removed entirely because it would be easier to support allowing the user to select packages appropriate for their platform in the future and ease the burden on the maintainers for keeping what amounted to a massive hash table. To see how we achieved this setup, check out the test cookbook postgresql recipe under the `test/` directory.
-
-#### original instance is the new default
-
-The previous version forced you down the path of creating virtual instances of a resolver or authoritative and left the original in place. This release now _assumes_ you want to modify the original instance or create a virtual one based upon the original instance setup. If you look at the single install recipes, you'll see how this is done as the default case. Any named install or config resources without a name will use the default setup instance that comes with the package.
-
-In most cases you want to only run one instance of PowerDNS Authoritative or Recursor on your system which is why we have now assumed this default for you.
-
-#### Instance naming scheme
-
-The instance naming schemes between versions of the 3.x cookbook were admittedly very inconsistent. We now directly follow the [virtual instance naming scheme documentation at PowerDNS](https://doc.powerdns.com/md/authoritative/running/#virtual-hosting) which will cause some breakage for you under the covers. You'll unfortunately have to review what your services are currently named and remove them if they clash with the updated naming scheme. Specifically check for underscores and hyphens in the name.
-
-Speaking of instance naming, we now reject any virtual service name that contains a hypen. You will see a cookbook compile error if that is the case.
-
-#### socket_dir property for recursor init service has been removed
-
-This was not implemented correctly in the previous versions and it has been removed since it is now implemented via the custom init script
-
 ### Platforms:
 
 - Ubuntu 14.04 and newer
@@ -53,16 +19,12 @@ This was not implemented correctly in the previous versions and it has been remo
 
 ### Chef:
 
-- Chef 12.14 or newer
+- Chef 13 or newer
 
 ### Init Systems:
 
 * SysV
 * systemd
-
-### Required Cookbooks:
-
-- apt
 
 ## Usage
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,19 +33,19 @@ module Pdns
   module RecursorHelpers
     include Pdns::Helpers
 
-    def systemd_name(name = '')
-      if name.empty?
-        'pdns-recursor'
+    def systemd_name(name)
+      if name && !name.empty?
+        "pdns-recursor@#{name}.service"
       else
-        "pdns-recursor@#{name}"
+        'pdns-recursor.service'
       end
     end
 
-    def sysvinit_name(name = '')
-      if name.empty?
-        'pdns-recursor'
-      else
+    def sysvinit_name(name)
+      if name && !name.empty?
         "pdns-recursor-#{name}"
+      else
+        'pdns-recursor'
       end
     end
 
@@ -67,11 +67,11 @@ module Pdns
       end
     end
 
-    def recursor_instance_config(name = '')
-      if name.empty?
-        'recursor.conf'
-      else
+    def recursor_instance_config(name)
+      if name && !name.empty?
         "recursor-#{name}.conf"
+      else
+        'recursor.conf'
       end
     end
   end
@@ -80,27 +80,27 @@ module Pdns
   module AuthoritativeHelpers
     include Pdns::Helpers
 
-    def systemd_name(name = '')
-      if name.empty?
-        'pdns'
+    def systemd_name(name)
+      if name && !name.empty?
+        "pdns@#{name}.service"
       else
-        "pdns@#{name}"
+        'pdns.service'
       end
     end
 
-    def sysvinit_name(name = '')
-      if name.empty?
-        'pdns'
-      else
+    def sysvinit_name(name)
+      if name && !name.empty?
         "pdns-#{name}"
+      else
+        'pdns'
       end
     end
 
-    def authoritative_instance_config(name = '')
-      if name.empty?
-        'pdns.conf'
-      else
+    def authoritative_instance_config(name)
+      if name && !name.empty?
         "pdns-#{name}.conf"
+      else
+        'pdns.conf'
       end
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,11 +8,9 @@ version          '4.4.0'
 source_url       'https://github.com/dnsimple/chef-pdns'
 issues_url       'https://github.com/dnsimple/chef-pdns/issues'
 
-chef_version '>= 12.14'
+chef_version '>= 13'
 
 supports 'ubuntu', '>= 14.04'
 supports 'debian', '>= 8.0'
 supports 'centos', '>= 6.0'
 supports 'redhat', '>= 6.0'
-
-depends 'apt'

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -30,7 +30,7 @@ provides :pdns_authoritative_config, platform_family: 'rhel' do |node| # ~FC005
 end
 
 include Pdns::AuthoritativeHelpers
-property :instance_name, String, name_property: true, callbacks: {
+property :instance_name, String, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
 }
 property :launch, Array, default: ['bind']
@@ -39,7 +39,7 @@ property :run_group, String, default: lazy { default_authoritative_run_user }
 property :run_user, String, default: lazy { default_authoritative_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
-property :socket_dir, String, default: lazy { |resource| "/var/run/#{resource.instance_name}" }
+property :socket_dir, String, default: '/var/run/pdns'
 property :setuid, String, default:  lazy { |resource| resource.run_user }
 property :setgid, String, default:  lazy { |resource| resource.run_group }
 

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -47,6 +47,7 @@ action :install do
   apt_package 'pdns-server' do
     action :install
     version new_resource.version
+    allow_failure true if node['platform_version'].to_i >= 18.04
   end
 
   apt_package 'pdns-server-dbg' do

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -25,14 +25,14 @@ provides :pdns_authoritative_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :instance_name, String, name_property: true
-property :version, [String, nil], default: nil
+property :version, String
+property :series, String, default: '41'
 property :debug, [true, false], default: false
 
 action :install do
   apt_repository 'powerdns-authoritative' do
     uri "http://repo.powerdns.com/#{node['platform']}"
-    distribution "#{node['lsb']['codename']}-auth-40"
+    distribution "#{node['lsb']['codename']}-auth-#{new_resource.series}"
     arch 'amd64'
     components ['main']
     key 'powerdns.asc'

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -21,8 +21,8 @@ provides :pdns_authoritative_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :instance_name, String, name_property: true
-property :version, [String, nil], default: nil
+property :version, String
+property :series, String, default: '41'
 property :debug, [true, false], default: false
 
 action :install do
@@ -31,18 +31,18 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-auth-40' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40'
+  yum_repository 'powerdns-authoritative' do
+    description 'PowerDNS repository for PowerDNS Authoritative'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/auth-#{new_resource.series}"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-auth-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40/debug'
+  yum_repository 'powerdns-auth-authoritative-debuginfo' do
+    description 'PowerDNS repository for PowerDNS Authoritative'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/auth-#{new_resource.series}/debug"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'

--- a/resources/authoritative_service_systemd.rb
+++ b/resources/authoritative_service_systemd.rb
@@ -22,7 +22,7 @@ provides :pdns_authoritative_service, os: 'linux' do |_node|
 end
 
 include Pdns::AuthoritativeHelpers
-property :instance_name, String, name_property: true, callbacks: {
+property :instance_name, String, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
 }
 property :config_dir, String, default: lazy { default_authoritative_config_directory }

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -22,7 +22,7 @@ provides :pdns_authoritative_service, os: 'linux' do |node|
 end
 
 include Pdns::AuthoritativeHelpers
-property :instance_name, String, name_property: true, callbacks: {
+property :instance_name, String, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
 }
 property :cookbook, String, default: 'pdns'

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -25,13 +25,13 @@ provides :pdns_recursor_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :instance_name, String, name_property: true
-property :version, [String, nil], default: nil
+property :series, String, default: '41'
+property :version, String
 
 action :install do
   apt_repository 'powerdns-recursor' do
     uri "http://repo.powerdns.com/#{node['platform']}"
-    distribution "#{node['lsb']['codename']}-rec-40"
+    distribution "#{node['lsb']['codename']}-rec-#{new_resource.series}"
     arch 'amd64'
     components ['main']
     key 'powerdns.asc'

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -27,6 +27,7 @@ end
 
 property :series, String, default: '41'
 property :version, String
+property :debug, [true, false], default: false
 
 action :install do
   apt_repository 'powerdns-recursor' do
@@ -46,6 +47,11 @@ action :install do
   apt_package 'pdns-recursor' do
     action :install
     version new_resource.version
+  end
+
+  apt_package 'pdns-recursor-dbg' do
+    action :install
+    only_if { new_resource.debug }
   end
 end
 

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -21,8 +21,8 @@ provides :pdns_recursor_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :instance_name, String, name_property: true
-property :version, [String, nil], default: nil
+property :series, String, default: '41'
+property :version, String
 property :debug, [true, false], default: false
 
 action :install do
@@ -34,18 +34,18 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-rec-40' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
+  yum_repository 'powerdns-recursor' do
+    description 'PowerDNS repository for PowerDNS Recursor'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/rec-#{new_resource.series}"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-rec-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
+  yum_repository 'powerdns-recursor-debug' do
+    description 'PowerDNS repository for PowerDNS Recursor with Debug Symbols'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/rec-#{new_resource.series}/debug"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe Pdns::RecursorHelpers do
     context 'without a name' do
       let(:instance) { '' }
       it 'returns the service name without a specific name' do
-        expect(subject.systemd_name(instance)).to eq 'pdns-recursor'
+        expect(subject.systemd_name(instance)).to eq 'pdns-recursor.service'
       end
     end
 
     context 'with a name' do
       let(:instance) { 'foo' }
       it 'returns the service name with a virtual instance name' do
-        expect(subject.systemd_name(instance)).to eq('pdns-recursor@foo')
+        expect(subject.systemd_name(instance)).to eq('pdns-recursor@foo.service')
       end
     end
   end
@@ -126,14 +126,14 @@ RSpec.describe Pdns::AuthoritativeHelpers do
     context 'without a name' do
       let(:instance) { '' }
       it 'returns the service name without a specific name' do
-        expect(subject.systemd_name(instance)).to eq 'pdns'
+        expect(subject.systemd_name(instance)).to eq 'pdns.service'
       end
     end
 
     context 'with a name' do
       let(:instance) { 'foo' }
       it 'returns the service name with a virtual instance name' do
-        expect(subject.systemd_name(instance)).to eq('pdns@foo')
+        expect(subject.systemd_name(instance)).to eq('pdns@foo.service')
       end
     end
   end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -25,7 +25,7 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-pdns_authoritative_install '' do
+pdns_authoritative_install 'default' do
   action :install
 end
 
@@ -36,7 +36,7 @@ pg_backend_package = value_for_platform_family(
 
 package pg_backend_package
 
-pdns_authoritative_config '' do
+pdns_authoritative_config 'default' do
   action :create
   launch ['gpgsql']
   variables(
@@ -46,10 +46,10 @@ pdns_authoritative_config '' do
     gpgsql_dbname: 'pdns',
     gpgsql_password: 'wadus'
   )
-  notifies :restart, 'pdns_authoritative_service[]'
+  notifies :restart, 'pdns_authoritative_service[default]'
 end
 
-pdns_authoritative_service '' do
+pdns_authoritative_service 'default' do
   action [:enable, :start]
 end
 

--- a/test/cookbooks/pdns_test/recipes/hyphens.rb
+++ b/test/cookbooks/pdns_test/recipes/hyphens.rb
@@ -1,15 +1,19 @@
 pdns_authoritative_config 'with-hyphen' do
+  instance_name 'with-hyphen'
   action :create
 end
 
 pdns_authoritative_service 'with-hyphen' do
+  instance_name 'with-hyphen'
   action :enable
 end
 
 pdns_recursor_config 'with-hyphen' do
+  instance_name 'with-hyphen'
   action :create
 end
 
 pdns_recursor_service 'with-hyphen' do
+  instance_name 'with-hyphen'
   action :enable
 end


### PR DESCRIPTION
This is a larger than expected PR which will be a breaking change to correct a poor assumption early on we made where you would run multiple instances of PowerDNS on one system. I think it's fair to assume most users will want to install and configure only a single instance of PowerDNS Authoritative and Recusor. We'll still continue to support both, but the new _default_ behavior now will be configuring and setting up the default packaged installation on most platforms.

A significant amount of energy was spent on Ubuntu 18.04 testing because of a descision they made to force the systemd-resolvd stub resolver to ON by default. This takes up port 53 on the system which breaks the installation of PowerDNS. I've added specific README documentation around this quirk as fixing the problem takes a few tricks that I would rather perform in a test wrapper cookbook than the cookbook itself since it messes with networking a bit.

All the changes here are for the following:

* Move to Chef 13+ since Chef 12 is EOL
* Removes Apt Cookbook dependency since it's now in Chef 13+
* Change instance_name to not be a name property anymore
* Add Ubuntu 18.04