### PR TITLE
Update dokken config and bump to Chef 13+

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -33,20 +33,16 @@ platforms:
       intermediate_instructions:
           - RUN /usr/bin/apt-get update
           - RUN /usr/bin/apt-get install dnsutils -y
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
   - name: centos-6
     driver:
       image: dokken/centos-6
+      pid_one_command: /sbin/init
 
   - name: centos-7
     driver:
       image: dokken/centos-7
-      platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
   - name: debian-8
     driver:
@@ -55,5 +51,4 @@ platforms:
       intermediate_instructions:
           - RUN /usr/bin/apt-get update
           - RUN /usr/bin/apt-get install dnsutils -y
-    volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+

--- a/README.md
+++ b/README.md
@@ -8,42 +8,6 @@ Provides resources for installing and configuring both PowerDNS authoritative an
 
 ## Requirements
 
-IMPORTANT: Please read the Deprecations and Compatibility Notes sections below since there are breaking changes between versions 2 and 3 of this cookbook.
-
-### Deprecations
-
-  - The recipe and attribute based way of setting different PowerDNS installs is completely deprecated, there are no  attributes in the newest version of this cookbok neither recipes to add to the run list.
-  - `pdnsrecord` and `domainrecord` resources have been deprecated since they were coupled with sqlite3 backend.
-  - Ubuntu 12.02 support has been removed, if you want this platform to be supported PRs are welcome, see the CONTRIBUTING.md file.
-
-### 4.x Compatibility Notes
-
-Users of the previous versions of the cookbook may find a few breaking changes. Here are the highlights:
-
-#### Chef 12.14 or newer
-
-To help clear up additional code and remove the 'yum' cookbook dependency, we have jumped up to Chef 12.14 as the minimum version. We'll look into the potential options of removing the 'apt' cookbook dependency as well.
-
-#### pdns_authoritative_backend has been removed
-
-This resource has been removed entirely because it would be easier to support allowing the user to select packages appropriate for their platform in the future and ease the burden on the maintainers for keeping what amounted to a massive hash table. To see how we achieved this setup, check out the test cookbook postgresql recipe under the `test/` directory.
-
-#### original instance is the new default
-
-The previous version forced you down the path of creating virtual instances of a resolver or authoritative and left the original in place. This release now _assumes_ you want to modify the original instance or create a virtual one based upon the original instance setup. If you look at the single install recipes, you'll see how this is done as the default case. Any named install or config resources without a name will use the default setup instance that comes with the package.
-
-In most cases you want to only run one instance of PowerDNS Authoritative or Recursor on your system which is why we have now assumed this default for you.
-
-#### Instance naming scheme
-
-The instance naming schemes between versions of the 3.x cookbook were admittedly very inconsistent. We now directly follow the [virtual instance naming scheme documentation at PowerDNS](https://doc.powerdns.com/md/authoritative/running/#virtual-hosting) which will cause some breakage for you under the covers. You'll unfortunately have to review what your services are currently named and remove them if they clash with the updated naming scheme. Specifically check for underscores and hyphens in the name.
-
-Speaking of instance naming, we now reject any virtual service name that contains a hypen. You will see a cookbook compile error if that is the case.
-
-#### socket_dir property for recursor init service has been removed
-
-This was not implemented correctly in the previous versions and it has been removed since it is now implemented via the custom init script
-
 ### Platforms:
 
 - Ubuntu 14.04 and newer
@@ -53,16 +17,12 @@ This was not implemented correctly in the previous versions and it has been remo
 
 ### Chef:
 
-- Chef 12.14 or newer
+- Chef 13 or newer
 
 ### Init Systems:
 
 * SysV
 * systemd
-
-### Required Cookbooks:
-
-- apt
 
 ## Usage
 
@@ -330,6 +290,7 @@ There is an specific file for testing guidelines on this cokbook: TESTING.md
 License & Authors
 -----------------
 - Author:: Aaron Kalin (<aaron.kalin@dnsimple.com>)
+- Author:: Amy Aronsohn (<amy.aronsohn@dnsimple.com>)
 - Author:: Jacobo García (<jacobo.garcia@dnsimple.com>)
 - Author:: Anthony Eden (<anthony.eden@dnsimple.com>)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,11 +8,9 @@ version          '4.4.0'
 source_url       'https://github.com/dnsimple/chef-pdns'
 issues_url       'https://github.com/dnsimple/chef-pdns/issues'
 
-chef_version '>= 12.14'
+chef_version '>= 13'
 
 supports 'ubuntu', '>= 14.04'
 supports 'debian', '>= 8.0'
 supports 'centos', '>= 6.0'
 supports 'redhat', '>= 6.0'
-
-depends 'apt'

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -40,8 +40,8 @@ property :run_user, String, default: lazy { default_authoritative_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
 property :socket_dir, String, default: lazy { |resource| "/var/run/#{resource.instance_name}" }
-property :setuid, String, default:  lazy(&:run_user)
-property :setgid, String, default:  lazy(&:run_group)
+property :setuid, String, default:  lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
+property :setgid, String, default:  lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
 property :source, String, default: 'authoritative_service.conf.erb'
 property :cookbook, String, default: 'pdns'

--- a/resources/recursor_config.rb
+++ b/resources/recursor_config.rb
@@ -39,8 +39,8 @@ property :run_group, String, default: lazy { default_recursor_run_user }
 property :run_user, String, default: lazy { default_recursor_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
-property :setuid, String, default: lazy(&:run_user)
-property :setgid, String, default: lazy(&:run_group)
+property :setuid, String, default: lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
+property :setgid, String, default: lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
 property :source, String, default: 'recursor_service.conf.erb'
 property :cookbook, String, default: 'pdns'

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -1,6 +1,9 @@
 apt_update 'RIGHT_MEOW'
 
-include_recipe 'postgresql::server'
+postgresql_server_install 'default' do
+  version '10'
+  action [:install, :create]
+end
 
 execute 'setup_postgres_user' do
   command "psql -c \"CREATE ROLE pdns PASSWORD 'wadus' SUPERUSER INHERIT LOGIN;\""


### PR DESCRIPTION
This is a smaller changeset pulled from #97 to help simplify the overall changes needed to get this cookbook working again and on a new platform.