### PR TITLE
Remove instance_name from install resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,10 @@ Installs PowerDNS authoritative server 4.X series using PowerDNS official reposi
 
 #### Properties
 
-| Name          | Class       |  Default value | Consistent?|
-|---------------|-------------|----------------|------------|
-| instance_name | String      | name_property  | Yes|
-| version       | String, nil | nil            | No |
-| debug         | true, false | false          | No |
+| Name          | Class       |  Default value |
+|---------------|-------------|----------------|
+| version       | String, nil | nil            |
+| debug         | true, false | false          |
 
 #### Usage example
 

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -40,8 +40,8 @@ property :run_user, String, default: lazy { default_authoritative_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
 property :socket_dir, String, default: lazy { |resource| "/var/run/#{resource.instance_name}" }
-property :setuid, String, default:  lazy(&:run_user)
-property :setgid, String, default:  lazy(&:run_group)
+property :setuid, String, default:  lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
+property :setgid, String, default:  lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
 property :source, String, default: 'authoritative_service.conf.erb'
 property :cookbook, String, default: 'pdns'

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -25,7 +25,6 @@ provides :pdns_authoritative_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
 

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -21,7 +21,6 @@ provides :pdns_authoritative_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
 

--- a/resources/recursor_config.rb
+++ b/resources/recursor_config.rb
@@ -39,8 +39,8 @@ property :run_group, String, default: lazy { default_recursor_run_user }
 property :run_user, String, default: lazy { default_recursor_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
-property :setuid, String, default: lazy(&:run_user)
-property :setgid, String, default: lazy(&:run_group)
+property :setuid, String, default: lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
+property :setgid, String, default: lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
 property :source, String, default: 'recursor_service.conf.erb'
 property :cookbook, String, default: 'pdns'

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -25,7 +25,6 @@ provides :pdns_recursor_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 
 action :install do

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -21,7 +21,6 @@ provides :pdns_recursor_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :instance_name, String, name_property: true
 property :version, [String, nil], default: nil
 property :debug, [true, false], default: false
 

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -1,6 +1,9 @@
 apt_update 'RIGHT_MEOW'
 
-include_recipe 'postgresql::server'
+postgresql_server_install 'default' do
+  version '10'
+  action [:install, :create]
+end
 
 execute 'setup_postgres_user' do
   command "psql -c \"CREATE ROLE pdns PASSWORD 'wadus' SUPERUSER INHERIT LOGIN;\""


### PR DESCRIPTION
This property is not used at all and is likely a leftover from when we did source based installations. I've also corrected a cookstyle issue which over-corrected a lazy property in the config resources. This was causing Chef to crash in many of the tests.