### PR TITLE
Add 'series' property for install resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,29 @@ Most of the properties are optional and have sane defaults, so they are only rec
 
 ### pdns_authoritative_install
 
-Installs PowerDNS authoritative server 4.X series using PowerDNS official repository in the supported platforms.
+Installs PowerDNS authoritative server 4.1.x series using PowerDNS official repository in the supported platforms.
 
 #### Properties
 
-| Name          | Class       |  Default value |
+| Name          | Type        |  Default value |
 |---------------|-------------|----------------|
-| version       | String, nil | nil            |
+| version       | String      | ''             |
+| series        | String      | '41'           |
 | debug         | true, false | false          |
 
-#### Usage example
+#### Usage examples
 
-Install a PowerDNS authoritative server package named `server-01` with the latest version available in the repository.
+Install the latest 4.1.x series PowerDNS Authoritative Server
 
+```ruby
+pdns_authoritative_install 'server_01'
 ```
+
+Install the latest 4.0.x series PowerDNS Authoritative Server
+
+```ruby
 pdns_authoritative_install 'server_01' do
-  action :install
+  series '40'
 end
 ```
 
@@ -179,22 +186,31 @@ end
 
 ### pdns_recursor_install
 
-Installs PowerDNS recursor 4.X series using PowerDNS official repository in the supported platforms.
+Installs PowerDNS recursor 4.1.x series using PowerDNS official repository in the supported platforms.
 
 #### Properties
 
-| Name           | Class       |  Default value  | Consistent? |
-|----------------|-------------|-----------------|-------------|
-| version        | String      | name_property   | Yes         |
-| debug          | True, False | String, nil     | No          |
+| Name           | Type        |  Default value  |
+|----------------|-------------|-----------------|
+| version        | String      | ''              |
+| series         | String      | '41'            |
+| debug          | true, false | false           |
 
-#### Usage Example
+#### Usage examples
 
-Install a 4. powerdns instance named 'my_recursor' on ubuntu 14.04:
+Install the latest 4.1.x release PowerDNS recursor
 
-    pdns_recursor_install 'my_recursor' do
-      version '4.0.4-1pdns.trusty'
-    end
+```ruby
+pdns_recursor_install 'latest_4_1_x_recursor'
+```
+
+Install the latest 4.0.x release PowerDNS recursor
+
+```ruby
+pdns_recursor_install 'my_recursor' do
+  series '40'
+end
+```
 
 ### pdns_recursor_service
 

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -25,13 +25,14 @@ provides :pdns_authoritative_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :version, [String, nil], default: nil
+property :version, String
+property :series, String, default: '41'
 property :debug, [true, false], default: false
 
 action :install do
   apt_repository 'powerdns-authoritative' do
     uri "http://repo.powerdns.com/#{node['platform']}"
-    distribution "#{node['lsb']['codename']}-auth-40"
+    distribution "#{node['lsb']['codename']}-auth-#{new_resource.series}"
     arch 'amd64'
     components ['main']
     key 'powerdns.asc'

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -28,7 +28,6 @@ property :debug, [true, false], default: false
 action :install do
   yum_package 'epel-release' do
     action :install
-    only_if { node['platform_version'].to_i == 6 }
   end
 
   yum_repository 'powerdns-authoritative' do

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -21,7 +21,8 @@ provides :pdns_authoritative_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :version, [String, nil], default: nil
+property :version, String
+property :series, String, default: '41'
 property :debug, [true, false], default: false
 
 action :install do
@@ -30,18 +31,18 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-auth-40' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40'
+  yum_repository 'powerdns-authoritative' do
+    description 'PowerDNS repository for PowerDNS Authoritative'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/auth-#{new_resource.series}"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-auth-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Authoritative - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-40/debug'
+  yum_repository 'powerdns-authoritative-debuginfo' do
+    description 'PowerDNS repository for PowerDNS Authoritative'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/auth-#{new_resource.series}/debug"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -25,12 +25,14 @@ provides :pdns_recursor_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 8
 end
 
-property :version, [String, nil], default: nil
+property :series, String, default: '41'
+property :version, String
+property :debug, [true, false], default: false
 
 action :install do
   apt_repository 'powerdns-recursor' do
     uri "http://repo.powerdns.com/#{node['platform']}"
-    distribution "#{node['lsb']['codename']}-rec-40"
+    distribution "#{node['lsb']['codename']}-rec-#{new_resource.series}"
     arch 'amd64'
     components ['main']
     key 'powerdns.asc'
@@ -46,10 +48,20 @@ action :install do
     action :install
     version new_resource.version
   end
+
+  apt_package 'pdns-recursor-dbg' do
+    action :install
+    only_if { new_resource.debug }
+  end
 end
 
 action :uninstall do
   apt_package 'pdns-recursor' do
     action :remove
+  end
+
+  apt_package 'pdns-recursor-dbg' do
+    action :remove
+    only_if { new_resource.debug }
   end
 end

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -28,10 +28,8 @@ property :debug, [true, false], default: false
 action :install do
   # We take advantage of the yum_repository call bellow that will reload yum sources
   # and will make epel repository available for the pdns-recursor dependency 'protobuf'
-
   yum_package 'epel-release' do
     action :install
-    only_if { node['platform_version'].to_i == 6 }
   end
 
   yum_repository 'powerdns-recursor' do

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -21,7 +21,8 @@ provides :pdns_recursor_install, platform_family: 'rhel' do |node|
   node['platform_version'].to_i >= 6
 end
 
-property :version, [String, nil], default: nil
+property :version, String
+property :series, String, default: '41'
 property :debug, [true, false], default: false
 
 action :install do
@@ -33,18 +34,18 @@ action :install do
     only_if { node['platform_version'].to_i == 6 }
   end
 
-  yum_repository 'powerdns-rec-40' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40'
+  yum_repository 'powerdns-recursor' do
+    description 'PowerDNS repository for PowerDNS Recursor'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/rec-#{new_resource.series}"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'
     action :create
   end
 
-  yum_repository 'powerdns-rec-40-debuginfo' do
-    description 'PowerDNS repository for PowerDNS Recursor - version 4.0.X debug symbols'
-    baseurl 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug'
+  yum_repository 'powerdns-recursor-debug' do
+    description 'PowerDNS repository for PowerDNS Recursor with Debug Symbols'
+    baseurl "http://repo.powerdns.com/centos/$basearch/$releasever/rec-#{new_resource.series}/debug"
     gpgkey 'https://repo.powerdns.com/FD380FBB-pub.asc'
     priority '90'
     includepkgs 'pdns*'


### PR DESCRIPTION
This breaks up #97 into a smaller PR that adds in a new series property. It corresponds to how PowerDNS organizes their package repositories. They are grouped by major and minor version numbers into a series. For example, 4.1.x is '41' and will be the new default in this PR.