### PR TITLE
Introduce virtual property for Authoriative installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ For advanced use it is recommended to take a look at the chef resources themselv
 
 ### Properties
 
-#### A note about instance names
+#### Virtual instances and instance name
 
-PowerDNS parses the name of the instance by breaking apart the first hyphen it sees so all virtual service names (ones without a blank string) start with the service type and a hyphen. For example:
+If you wish to create multiple running copies of PowerDNS via Virtual Configurations you can set the virtual property on both the config and service resources. The name of the virtual instance will default to either the name of the resource or the 'instance_name' value of the resource if it is set. PowerDNS parses the name of the instance by breaking apart the first hyphen it sees so all virtual service names start with the service type and a hyphen. For example:
 
 ```ruby
 pdns_authoritative_config 'server_01' do
-  action :create
+  virtual true
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -60,9 +60,11 @@ pdns_authoritative_config 'server_01' do
     gpgsql_dbname: 'pdns',
     gpgsql_password: 'wadus'
   )
+  action :create
 end
 
 pdns_authoritative_service 'service_01' do
+  virtual true
   action [:enable, :start]
 end
 ```
@@ -135,6 +137,7 @@ Creates a PowerDNS recursor configuration, there is a fixed set of required prop
 | Name           | Class      |  Default value  | Consistent? |
 |----------------|------------|-----------------|-------------|
 | instance_name  | String     | name_property   | Yes         |
+| virtual        | Boolean    | false           | No          |
 | launch         | Array, nil | ['bind']        | No          |
 | config_dir     | String     | see `default_authoritative_config_directory` helper method | Yes |
 | socket_dir     | String     | "/var/run/#{resource.instance_name}" | Yes |
@@ -154,7 +157,7 @@ Create a PowerDNS authoritative configuration file named `server-01`:
 
 ```
 pdns_authoritative_config 'server_01' do
-  action :create
+  virtual true
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -166,12 +169,13 @@ pdns_authoritative_config 'server_01' do
     api: true,
     api-_eadonly: true
     )
+  action :create
 end
 ```
 
 ### pdns_authoritative_service
 
-Creates a init service to manage a PowerDNS authoritative instance. This service supports all the regular actions (start, stop, restart, etc.). Check the compatibility section to see which init services are supported.
+Creates a service to manage a PowerDNS authoritative instance. This service supports all the regular actions (start, stop, restart, etc.). Check the compatibility section to see which init services are supported.
 
 *Important:* services are not restarted or reloaded automatically on config changes in this cookbook, you need to add this in your wrapper cookbook if you desire this functionality, the `pdns_authoritative_service` cookbook provides actions to do it.
 
@@ -180,6 +184,7 @@ Creates a init service to manage a PowerDNS authoritative instance. This service
 | Name           | Class       |  Default value                                             | Consistent? |
 |----------------|-------------|------------------------------------------------------------|-------------|
 | instance_name  | String      | name_property                                              | Yes         |
+| virtual        | Boolean     | false                                                      | No          |
 | cookbook       | String      | 'pdns'                                                     | No          |
 | source         | String      | 'authoritative.init.debian.erb'                            | No          |
 | config_dir     | String      | See `default_authoritative_config_directory` helper method | Yes         |
@@ -188,8 +193,19 @@ Creates a init service to manage a PowerDNS authoritative instance. This service
 
 #### Usage example
 
+To enable and start the default PowerDNS Authoritative server
+
+```ruby
+pdns_authoritative_service 'default' do
+  action [:enable, :start]
+end
 ```
+
+To enable and start a virtual PowerDNS instance called 'server_01'
+
+```ruby
 pdns_authoritative_service 'server_01' do
+  virtual true
   action [:enable, :start]
 end
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,28 +80,16 @@ module Pdns
   module AuthoritativeHelpers
     include Pdns::Helpers
 
-    def systemd_name(name = '')
-      if name.empty?
-        'pdns'
-      else
-        "pdns@#{name}"
-      end
+    def systemd_name(name, virtual)
+      virtual ? "pdns@#{name}.service" : 'pdns.service'
     end
 
-    def sysvinit_name(name = '')
-      if name.empty?
-        'pdns'
-      else
-        "pdns-#{name}"
-      end
+    def sysvinit_name(name, virtual)
+      virtual ? "pdns-#{name}" : 'pdns'
     end
 
-    def authoritative_instance_config(name = '')
-      if name.empty?
-        'pdns.conf'
-      else
-        "pdns-#{name}.conf"
-      end
+    def authoritative_instance_config(name, virtual)
+      virtual ? "pdns-#{name}.conf" : 'pdns.conf'
     end
 
     def default_authoritative_run_user

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -41,7 +41,7 @@ property :run_group, String, default: lazy { default_authoritative_run_user }
 property :run_user, String, default: lazy { default_authoritative_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
-property :socket_dir, String, default: lazy { |resource| "/var/run/#{resource.instance_name}" }
+property :socket_dir, String, default: '/var/run'
 property :setuid, String, default:  lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
 property :setgid, String, default:  lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
@@ -61,17 +61,6 @@ action :create do
     members [new_resource.run_user]
     system true
     append true
-    action :create
-  end
-
-  directory new_resource.socket_dir do
-    owner new_resource.run_user
-    group new_resource.run_group
-    # Because of the DynListener creation before dropping privileges, the
-    # socket-directory has to be '0777' for now
-    # Issue: https://github.com/PowerDNS/pdns/issues/4826
-    mode Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd) ? '0777' : '0755'
-    recursive true
     action :create
   end
 

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -32,7 +32,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :launch, Array, default: ['bind']
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 property :run_group, String, default: lazy { default_authoritative_run_user }
@@ -80,7 +82,7 @@ action :create do
     action :create
   end
 
-  template "#{new_resource.config_dir}/#{authoritative_instance_config(new_resource.instance_name)}" do
+  template "#{new_resource.config_dir}/#{authoritative_instance_config(new_resource.instance_name, new_resource.virtual)}" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'

--- a/resources/authoritative_service_systemd.rb
+++ b/resources/authoritative_service_systemd.rb
@@ -24,7 +24,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 
 action :enable do

--- a/resources/authoritative_service_systemd.rb
+++ b/resources/authoritative_service_systemd.rb
@@ -30,28 +30,28 @@ property :virtual, [true, false], default: false
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 
 action :enable do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -24,7 +24,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :cookbook, String, default: 'pdns'
 property :source, String
 property :config_dir, String, default: lazy { default_authoritative_config_directory }

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -45,33 +45,33 @@ action :enable do
 
   # Create a symlink to the original pdns script to make a virtual instance
   # https://doc.powerdns.com/md/authoritative/running/#virtual-hosting
-  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name)}" do
+  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name, new_resource.virtual)}" do
     to '/etc/init.d/pdns'
-    not_if { new_resource.instance_name.empty? || new_resource.property_is_set?(:source) }
+    not_if { new_resource.virtual || new_resource.property_is_set?(:source) }
   end
 
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -33,7 +33,7 @@ property :config_dir, String, default: lazy { default_authoritative_config_direc
 property :variables, Hash, default: {}
 
 action :enable do
-  template "/etc/init.d/#{sysvinit_name}" do
+  template "/etc/init.d/#{sysvinit_name(new_resource.instance_name, false)}" do
     source new_resource.source
     owner 'root'
     group 'root'
@@ -47,7 +47,7 @@ action :enable do
   # https://doc.powerdns.com/md/authoritative/running/#virtual-hosting
   link "/etc/init.d/#{sysvinit_name(new_resource.instance_name, new_resource.virtual)}" do
     to '/etc/init.d/pdns'
-    not_if { new_resource.virtual || new_resource.property_is_set?(:source) }
+    only_if { new_resource.virtual }
   end
 
   service sysvinit_name(new_resource.instance_name, new_resource.virtual) do

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -122,50 +122,50 @@ RSpec.describe Pdns::AuthoritativeHelpers do
     DummyClass.new
   end
 
+  let(:virtual) { false }
+  let(:instance) { 'foo' }
+
   describe '#systemd_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.systemd_name(instance)).to eq 'pdns'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.systemd_name(instance, virtual)).to eq('pdns@foo.service')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.systemd_name(instance)).to eq('pdns@foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.systemd_name(instance, virtual)).to eq 'pdns.service'
       end
     end
   end
 
   describe '#sysvinit_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.sysvinit_name(instance)).to eq 'pdns'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq('pdns-foo')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.sysvinit_name(instance)).to eq('pdns-foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq 'pdns'
       end
     end
   end
 
   describe '#authoritative_instance_config' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the default configuration' do
-        expect(subject.authoritative_instance_config(instance)).to eq 'pdns.conf'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the config with a virtual instance name' do
+        expect(subject.authoritative_instance_config(instance, virtual)).to eq 'pdns-foo.conf'
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the config with a virtual instance name' do
-        expect(subject.authoritative_instance_config(instance)).to eq('pdns-foo.conf')
+    context 'is not a virtual instance' do
+      it 'returns the default configuration' do
+        expect(subject.authoritative_instance_config(instance, virtual)).to eq('pdns.conf')
       end
     end
   end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -55,6 +55,6 @@ pdns_authoritative_service 'default' do
 end
 
 pdns_authoritative_service 'server_02' do
-  instance_name 'server_02'
+  virtual true
   action :restart
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -51,10 +51,10 @@ file "#{config_dir}/example.org.zone" do
 end
 
 pdns_authoritative_service 'default' do
-  action :restart
+  action [:enable, :restart]
 end
 
 pdns_authoritative_service 'server_02' do
   virtual true
-  action :restart
+  action [:enable, :restart]
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -1,14 +1,6 @@
-pdns_authoritative_install '' do
-  action :install
-end
+pdns_authoritative_install 'default'
 
-pdns_authoritative_config '' do
-  action :create
-end
-
-pdns_authoritative_install 'server_02' do
-  action :install
-end
+pdns_authoritative_config 'default'
 
 config_dir = case node['platform_family']
              when 'debian'
@@ -18,7 +10,7 @@ config_dir = case node['platform_family']
              end
 
 pdns_authoritative_config 'server_02' do
-  action :create
+  virtual true
   run_user 'another-pdns'
   run_group 'another-pdns'
   run_user_home '/var/lib/another-pdns'
@@ -58,10 +50,11 @@ file "#{config_dir}/example.org.zone" do
   mode '0440'
 end
 
-pdns_authoritative_service '' do
-  action [:enable, :start]
+pdns_authoritative_service 'default' do
+  action :restart
 end
 
 pdns_authoritative_service 'server_02' do
-  action [:enable, :start]
+  instance_name 'server_02'
+  action :restart
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -28,9 +28,7 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-pdns_authoritative_install '' do
-  action :install
-end
+pdns_authoritative_install 'default'
 
 pg_backend_package = value_for_platform_family(
   'rhel' => 'pdns-backend-postgresql',
@@ -39,8 +37,7 @@ pg_backend_package = value_for_platform_family(
 
 package pg_backend_package
 
-pdns_authoritative_config '' do
-  action :create
+pdns_authoritative_config 'default' do
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -49,10 +46,10 @@ pdns_authoritative_config '' do
     gpgsql_dbname: 'pdns',
     gpgsql_password: 'wadus'
   )
-  notifies :restart, 'pdns_authoritative_service[]'
+  notifies :restart, 'pdns_authoritative_service[default]'
 end
 
-pdns_authoritative_service '' do
+pdns_authoritative_service 'default' do
   action [:enable, :start]
 end
 


### PR DESCRIPTION
A major source of confusion in this cookbook resolves around the capability of PowerDNS to support virtual instances. It has been 'implied' around the instance_name property, but it is very confusing and not very explicit. Adding a new boolean property called 'virtual' lets us explicitly mark these instances so that the proper service and configurations can be created that PowerDNS expects.