### PR TITLE
Introduce virtual property for Recursor installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,13 +257,14 @@ Sets up a PowerDNS recursor instance using the appropiate init system .
 
 #### Properties
 
-| Name           | Class      |  Default value                                        | Consistent? |
-|----------------|------------|-------------------------------------------------------|-------------|
-| instance_name  | String     | name_property                                         | Yes         |
-| config_dir     | String     | see `default_recursor_config_directory` helper method | Yes         |
-| cookbook (SysVinit)      | String,nil | 'pdns'                                                | No          |
-| source  (SysVinit)       | String,nil | 'recursor.init.#{node['platform_family']}.erb'                            | No          |
-| variables (SysVinit)    | Hash     | {} | No     |
+| Name                     | Class      |  Default value                                        |
+|--------------------------|------------|-------------------------------------------------------|
+| instance_name            | String     | Resource name                                         |
+| virtual                  | Boolean    | false                                                 |
+| config_dir               | String     | see `default_recursor_config_directory` helper method |
+| cookbook (SysVinit)      | String,nil | 'pdns'                                                |
+| source  (SysVinit)       | String,nil | 'recursor.init.#{node['platform_family']}.erb'        |
+| variables (SysVinit)     | Hash       | {}                                                    |
 
 - `config_dir`: Path of the recursor configuration directory.
 - `cookbook`: Cookbook for a custom configuration template (Applied only when using SysVinit).
@@ -272,12 +273,23 @@ Sets up a PowerDNS recursor instance using the appropiate init system .
 
 #### Usage Example
 
-Configure a PowerDNS recursor service instance named 'my_recursor' in your wrapper cookbook for Acme Corp with a custom template named `my-recursor.erb`
+Disable the default PowerDNS recursor install service
 
-    pdns_recursor_service 'my_recursor' do
-      source 'my-recursor.erb'
-      cookbook 'acme-pdns-recursor'
-    end
+```ruby
+pdns_recursor_service 'default' do
+  action [:disable, :stop]
+end
+```
+
+Configure a virtual PowerDNS recursor service instance named 'my_recursor' in your wrapper cookbook for Acme Corp with a custom template named `my-recursor.erb`
+
+```ruby
+pdns_recursor_service 'my_recursor' do
+  virtual true
+  source 'my-recursor.erb'
+  cookbook 'acme-pdns-recursor'
+end
+```
 
 ### pdns_recursor_config
 
@@ -285,26 +297,28 @@ Creates a PowerDNS recursor configuration.
 
 #### Properties
 
-|           | Name           | Class       |  Default value                                         | Consistent? |
-|----------------|-------------|--------------------------------------------------------|-------------|
-| instance_name  | String      | name_property                                          | Yes         |
-| config_dir     | String      | see `default_recursor_config_directory` helper method  | Yes         |
-| socket_dir     | String      | /var/run/#{resource.instance_name}                     | Yes         |
-| run_group      | String      | see `default_recursor_run_user` helper method          | No          |
-| run_user       | String      | see `default_recursor_run_user` helper method          | No          |
-| run_user_home  | String      | see `default_user_attributes` helper method            | No          |
-| run_user_shell | String      | see `default_user_attributes` helper method            | No          |
-| setuid         | String      | resource.run_user                                      | No          |
-| setgid         | String      | resource.run_group                                     | No          |
-| source         | String, nil | 'recursor_service.conf.erb'                            | No          |
-| cookbook       | String, nil | 'pdns'                                                 | No          |
-| variables      | Hash        | {}                                                     | No          |
+| Name           | Class       |  Default value                                         |
+|----------------|-------------|--------------------------------------------------------|
+| instance_name  | String      | Resource name                                          |
+| virtual        | Boolean     | false                                                  |
+| config_dir     | String      | see `default_recursor_config_directory` helper method  |
+| socket_dir     | String      | /var/run/#{resource.instance_name}                     |
+| run_group      | String      | see `default_recursor_run_user` helper method          |
+| run_user       | String      | see `default_recursor_run_user` helper method          |
+| run_user_home  | String      | see `default_user_attributes` helper method            |
+| run_user_shell | String      | see `default_user_attributes` helper method            |
+| setuid         | String      | resource.run_user                                      |
+| setgid         | String      | resource.run_group                                     |
+| source         | String, nil | 'recursor_service.conf.erb'                            |
+| cookbook       | String, nil | 'pdns'                                                 |
+| variables      | Hash        | {}                                                     |
 
-- `config_dir` (C): Path of the recursor configuration directory.
-- `socket_dir` (C): Directory where sockets are created.
-- `source` (C): Name of the recursor custom template.
-- `socket_dir` (C): Directory where sockets are created.
-- `cookbook` (C): Cookbook for a custom configuration template
+- `virtual` : Is this a virtual instance or the default?
+- `config_dir` : Path of the recursor configuration directory.
+- `socket_dir` : Directory where sockets are created.
+- `source` : Name of the recursor custom template.
+- `socket_dir` : Directory where sockets are created.
+- `cookbook` : Cookbook for a custom configuration template
 - `variables`: Variables for the configuration template.
 - `run_group`: Unix group that runs the recursor.
 - `run_user`: Unix user that runs the recursor.
@@ -313,13 +327,26 @@ Creates a PowerDNS recursor configuration.
 
 #### Usage Example
 
+Customize the default recursor installation and change it's port to 54:
+
+```ruby
+pdns_recursor_config 'default' do
+  variables(
+    'local-port' => '54'
+  )
+end
+```
+
 Create a PowerDNS recursor configuration named 'my_recursor' in your wrapper cookbook for Acme Corp which uses a custom template named `my-recursor.erb` and a few attributes:
 
-    pdns_recursor_config 'my_recursor' do
-      source 'my-recursor.erb'
-      cookbook 'acme-pdns-recursor'
-      variables(client-tcp-timeout: '20', loglevel: '5', network-timeout: '2000')
-    end
+```ruby
+pdns_recursor_config 'my_recursor' do
+  virtual true
+  source 'my-recursor.erb'
+  cookbook 'acme-pdns-recursor'
+  variables(client-tcp-timeout: '20', loglevel: '5', network-timeout: '2000')
+end
+```
 
 #### Virtual Hosting
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ For advanced use it is recommended to take a look at the chef resources themselv
 
 ### Properties
 
-#### A note about instance names
+#### Virtual instances and instance name
 
-PowerDNS parses the name of the instance by breaking apart the first hyphen it sees so all virtual service names (ones without a blank string) start with the service type and a hyphen. For example:
+If you wish to create multiple running copies of PowerDNS via Virtual Configurations you can set the virtual property on both the config and service resources. The name of the virtual instance will default to either the name of the resource or the 'instance_name' value of the resource if it is set. PowerDNS parses the name of the instance by breaking apart the first hyphen it sees so all virtual service names start with the service type and a hyphen. For example:
 
 ```ruby
 pdns_authoritative_config 'server_01' do
-  action :create
+  virtual true
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -60,9 +60,11 @@ pdns_authoritative_config 'server_01' do
     gpgsql_dbname: 'pdns',
     gpgsql_password: 'wadus'
   )
+  action :create
 end
 
 pdns_authoritative_service 'service_01' do
+  virtual true
   action [:enable, :start]
 end
 ```
@@ -135,6 +137,7 @@ Creates a PowerDNS recursor configuration, there is a fixed set of required prop
 | Name           | Class      |  Default value  | Consistent? |
 |----------------|------------|-----------------|-------------|
 | instance_name  | String     | name_property   | Yes         |
+| virtual        | Boolean    | false           | No          |
 | launch         | Array, nil | ['bind']        | No          |
 | config_dir     | String     | see `default_authoritative_config_directory` helper method | Yes |
 | socket_dir     | String     | "/var/run/#{resource.instance_name}" | Yes |
@@ -154,7 +157,7 @@ Create a PowerDNS authoritative configuration file named `server-01`:
 
 ```
 pdns_authoritative_config 'server_01' do
-  action :create
+  virtual true
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -166,12 +169,13 @@ pdns_authoritative_config 'server_01' do
     api: true,
     api-_eadonly: true
     )
+  action :create
 end
 ```
 
 ### pdns_authoritative_service
 
-Creates a init service to manage a PowerDNS authoritative instance. This service supports all the regular actions (start, stop, restart, etc.). Check the compatibility section to see which init services are supported.
+Creates a service to manage a PowerDNS authoritative instance. This service supports all the regular actions (start, stop, restart, etc.). Check the compatibility section to see which init services are supported.
 
 *Important:* services are not restarted or reloaded automatically on config changes in this cookbook, you need to add this in your wrapper cookbook if you desire this functionality, the `pdns_authoritative_service` cookbook provides actions to do it.
 
@@ -180,6 +184,7 @@ Creates a init service to manage a PowerDNS authoritative instance. This service
 | Name           | Class       |  Default value                                             | Consistent? |
 |----------------|-------------|------------------------------------------------------------|-------------|
 | instance_name  | String      | name_property                                              | Yes         |
+| virtual        | Boolean     | false                                                      | No          |
 | cookbook       | String      | 'pdns'                                                     | No          |
 | source         | String      | 'authoritative.init.debian.erb'                            | No          |
 | config_dir     | String      | See `default_authoritative_config_directory` helper method | Yes         |
@@ -188,8 +193,19 @@ Creates a init service to manage a PowerDNS authoritative instance. This service
 
 #### Usage example
 
+To enable and start the default PowerDNS Authoritative server
+
+```ruby
+pdns_authoritative_service 'default' do
+  action [:enable, :start]
+end
 ```
+
+To enable and start a virtual PowerDNS instance called 'server_01'
+
+```ruby
 pdns_authoritative_service 'server_01' do
+  virtual true
   action [:enable, :start]
 end
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,20 +33,12 @@ module Pdns
   module RecursorHelpers
     include Pdns::Helpers
 
-    def systemd_name(name = '')
-      if name.empty?
-        'pdns-recursor'
-      else
-        "pdns-recursor@#{name}"
-      end
+    def systemd_name(name, virtual)
+      virtual ? "pdns-recursor@#{name}.service" : 'pdns-recursor.service'
     end
 
-    def sysvinit_name(name = '')
-      if name.empty?
-        'pdns-recursor'
-      else
-        "pdns-recursor-#{name}"
-      end
+    def sysvinit_name(name, virtual)
+      virtual ? "pdns-recursor-#{name}" : 'pdns-recursor'
     end
 
     def default_recursor_run_user
@@ -67,12 +59,8 @@ module Pdns
       end
     end
 
-    def recursor_instance_config(name = '')
-      if name.empty?
-        'recursor.conf'
-      else
-        "recursor-#{name}.conf"
-      end
+    def recursor_instance_config(name, virtual)
+      virtual ? "recursor-#{name}.conf" : 'recursor.conf'
     end
   end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,28 +80,16 @@ module Pdns
   module AuthoritativeHelpers
     include Pdns::Helpers
 
-    def systemd_name(name = '')
-      if name.empty?
-        'pdns'
-      else
-        "pdns@#{name}"
-      end
+    def systemd_name(name, virtual)
+      virtual ? "pdns@#{name}.service" : 'pdns.service'
     end
 
-    def sysvinit_name(name = '')
-      if name.empty?
-        'pdns'
-      else
-        "pdns-#{name}"
-      end
+    def sysvinit_name(name, virtual)
+      virtual ? "pdns-#{name}" : 'pdns'
     end
 
-    def authoritative_instance_config(name = '')
-      if name.empty?
-        'pdns.conf'
-      else
-        "pdns-#{name}.conf"
-      end
+    def authoritative_instance_config(name, virtual)
+      virtual ? "pdns-#{name}.conf" : 'pdns.conf'
     end
 
     def default_authoritative_run_user

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -41,7 +41,7 @@ property :run_group, String, default: lazy { default_authoritative_run_user }
 property :run_user, String, default: lazy { default_authoritative_run_user }
 property :run_user_home, String, default: lazy { default_user_attributes[:home] }
 property :run_user_shell, String, default: lazy { default_user_attributes[:shell] }
-property :socket_dir, String, default: lazy { |resource| "/var/run/#{resource.instance_name}" }
+property :socket_dir, String, default: '/var/run'
 property :setuid, String, default:  lazy { |resource| resource.run_user } # rubocop:disable Style/SymbolProc
 property :setgid, String, default:  lazy { |resource| resource.run_group } # rubocop:disable Style/SymbolProc
 
@@ -61,17 +61,6 @@ action :create do
     members [new_resource.run_user]
     system true
     append true
-    action :create
-  end
-
-  directory new_resource.socket_dir do
-    owner new_resource.run_user
-    group new_resource.run_group
-    # Because of the DynListener creation before dropping privileges, the
-    # socket-directory has to be '0777' for now
-    # Issue: https://github.com/PowerDNS/pdns/issues/4826
-    mode Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd) ? '0777' : '0755'
-    recursive true
     action :create
   end
 

--- a/resources/authoritative_config.rb
+++ b/resources/authoritative_config.rb
@@ -32,7 +32,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :launch, Array, default: ['bind']
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 property :run_group, String, default: lazy { default_authoritative_run_user }
@@ -80,7 +82,7 @@ action :create do
     action :create
   end
 
-  template "#{new_resource.config_dir}/#{authoritative_instance_config(new_resource.instance_name)}" do
+  template "#{new_resource.config_dir}/#{authoritative_instance_config(new_resource.instance_name, new_resource.virtual)}" do
     source new_resource.source
     cookbook new_resource.cookbook
     owner 'root'

--- a/resources/authoritative_service_systemd.rb
+++ b/resources/authoritative_service_systemd.rb
@@ -24,7 +24,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 
 action :enable do

--- a/resources/authoritative_service_systemd.rb
+++ b/resources/authoritative_service_systemd.rb
@@ -30,28 +30,28 @@ property :virtual, [true, false], default: false
 property :config_dir, String, default: lazy { default_authoritative_config_directory }
 
 action :enable do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -24,7 +24,9 @@ end
 include Pdns::AuthoritativeHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :cookbook, String, default: 'pdns'
 property :source, String
 property :config_dir, String, default: lazy { default_authoritative_config_directory }

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -45,33 +45,33 @@ action :enable do
 
   # Create a symlink to the original pdns script to make a virtual instance
   # https://doc.powerdns.com/md/authoritative/running/#virtual-hosting
-  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name)}" do
+  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name, new_resource.virtual)}" do
     to '/etc/init.d/pdns'
-    not_if { new_resource.instance_name.empty? || new_resource.property_is_set?(:source) }
+    not_if { new_resource.virtual || new_resource.property_is_set?(:source) }
   end
 
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/resources/authoritative_service_sysvinit.rb
+++ b/resources/authoritative_service_sysvinit.rb
@@ -33,7 +33,7 @@ property :config_dir, String, default: lazy { default_authoritative_config_direc
 property :variables, Hash, default: {}
 
 action :enable do
-  template "/etc/init.d/#{sysvinit_name}" do
+  template "/etc/init.d/#{sysvinit_name(new_resource.instance_name, false)}" do
     source new_resource.source
     owner 'root'
     group 'root'
@@ -47,7 +47,7 @@ action :enable do
   # https://doc.powerdns.com/md/authoritative/running/#virtual-hosting
   link "/etc/init.d/#{sysvinit_name(new_resource.instance_name, new_resource.virtual)}" do
     to '/etc/init.d/pdns'
-    not_if { new_resource.virtual || new_resource.property_is_set?(:source) }
+    only_if { new_resource.virtual }
   end
 
   service sysvinit_name(new_resource.instance_name, new_resource.virtual) do

--- a/resources/recursor_service_systemd.rb
+++ b/resources/recursor_service_systemd.rb
@@ -24,7 +24,9 @@ end
 include Pdns::RecursorHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :config_dir, String, default: lazy { default_recursor_config_directory }
 
 action :enable do
@@ -33,31 +35,31 @@ action :enable do
   service 'pdns-recursor' do
     supports restart: true, status: true
     action [:disable, :stop]
-    only_if { new_resource.instance_name.empty? }
+    not_if { new_resource.virtual }
   end
 
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service systemd_name(new_resource.instance_name) do
+  service systemd_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/resources/recursor_service_sysvinit.rb
+++ b/resources/recursor_service_sysvinit.rb
@@ -24,7 +24,9 @@ end
 include Pdns::RecursorHelpers
 property :instance_name, String, name_property: true, callbacks: {
   'should not contain a hyphen' => ->(param) { !param.include?('-') },
+  'should not be blank' => ->(param) { !param.empty? },
 }
+property :virtual, [true, false], default: false
 property :cookbook, String, default: 'pdns'
 property :config_dir, String, default: lazy { default_recursor_config_directory }
 property :source, String, default: lazy { "recursor.init.#{node['platform_family']}.erb" }
@@ -41,33 +43,33 @@ action :enable do
     action :create
   end
 
-  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name)}" do
+  link "/etc/init.d/#{sysvinit_name(new_resource.instance_name, new_resource.virtual)}" do
     to '/etc/init.d/pdns-recursor'
-    not_if { new_resource.instance_name.empty? }
+    only_if { new_resource.virtual }
   end
 
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :enable
   end
 end
 
 action :start do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :start
   end
 end
 
 action :stop do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :stop
   end
 end
 
 action :restart do
-  service sysvinit_name(new_resource.instance_name) do
+  service sysvinit_name(new_resource.instance_name, new_resource.virtual) do
     supports restart: true, status: true
     action :restart
   end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -33,34 +33,35 @@ RSpec.describe Pdns::RecursorHelpers do
     DummyClass.new
   end
 
+  let(:virtual) { false }
+  let(:instance) { 'foo' }
+
   describe '#systemd_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.systemd_name(instance)).to eq 'pdns-recursor'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.systemd_name(instance, virtual)).to eq('pdns-recursor@foo.service')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.systemd_name(instance)).to eq('pdns-recursor@foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.systemd_name(instance, virtual)).to eq 'pdns-recursor.service'
       end
     end
   end
 
   describe '#sysvinit_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.sysvinit_name(instance)).to eq 'pdns-recursor'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq('pdns-recursor-foo')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.sysvinit_name(instance)).to eq('pdns-recursor-foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq 'pdns-recursor'
       end
     end
   end
@@ -98,17 +99,16 @@ RSpec.describe Pdns::RecursorHelpers do
   end
 
   describe '#recursor_instance_config' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the default configuration' do
-        expect(subject.recursor_instance_config(instance)).to eq 'recursor.conf'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the config with a virtual instance name' do
+        expect(subject.recursor_instance_config(instance, virtual)).to eq('recursor-foo.conf')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the config with a virtual instance name' do
-        expect(subject.recursor_instance_config(instance)).to eq('recursor-foo.conf')
+    context 'is not a virtual instance' do
+      it 'returns the default configuration name' do
+        expect(subject.recursor_instance_config(instance, virtual)).to eq 'recursor.conf'
       end
     end
   end

--- a/spec/libraries/helpers_spec.rb
+++ b/spec/libraries/helpers_spec.rb
@@ -122,50 +122,50 @@ RSpec.describe Pdns::AuthoritativeHelpers do
     DummyClass.new
   end
 
+  let(:virtual) { false }
+  let(:instance) { 'foo' }
+
   describe '#systemd_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.systemd_name(instance)).to eq 'pdns'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.systemd_name(instance, virtual)).to eq('pdns@foo.service')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.systemd_name(instance)).to eq('pdns@foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.systemd_name(instance, virtual)).to eq 'pdns.service'
       end
     end
   end
 
   describe '#sysvinit_name' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the service name without a specific name' do
-        expect(subject.sysvinit_name(instance)).to eq 'pdns'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the service name with a virtual instance name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq('pdns-foo')
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the service name with a virtual instance name' do
-        expect(subject.sysvinit_name(instance)).to eq('pdns-foo')
+    context 'is not a virtual instance' do
+      it 'returns the service name without a specific name' do
+        expect(subject.sysvinit_name(instance, virtual)).to eq 'pdns'
       end
     end
   end
 
   describe '#authoritative_instance_config' do
-    context 'without a name' do
-      let(:instance) { '' }
-      it 'returns the default configuration' do
-        expect(subject.authoritative_instance_config(instance)).to eq 'pdns.conf'
+    context 'is a virtual instance' do
+      let(:virtual) { true }
+      it 'returns the config with a virtual instance name' do
+        expect(subject.authoritative_instance_config(instance, virtual)).to eq 'pdns-foo.conf'
       end
     end
 
-    context 'with a name' do
-      let(:instance) { 'foo' }
-      it 'returns the config with a virtual instance name' do
-        expect(subject.authoritative_instance_config(instance)).to eq('pdns-foo.conf')
+    context 'is not a virtual instance' do
+      it 'returns the default configuration' do
+        expect(subject.authoritative_instance_config(instance, virtual)).to eq('pdns.conf')
       end
     end
   end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -55,6 +55,6 @@ pdns_authoritative_service 'default' do
 end
 
 pdns_authoritative_service 'server_02' do
-  instance_name 'server_02'
+  virtual true
   action :restart
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -51,10 +51,10 @@ file "#{config_dir}/example.org.zone" do
 end
 
 pdns_authoritative_service 'default' do
-  action :restart
+  action [:enable, :restart]
 end
 
 pdns_authoritative_service 'server_02' do
   virtual true
-  action :restart
+  action [:enable, :restart]
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_multi.rb
@@ -1,14 +1,6 @@
-pdns_authoritative_install '' do
-  action :install
-end
+pdns_authoritative_install 'default'
 
-pdns_authoritative_config '' do
-  action :create
-end
-
-pdns_authoritative_install 'server_02' do
-  action :install
-end
+pdns_authoritative_config 'default'
 
 config_dir = case node['platform_family']
              when 'debian'
@@ -18,7 +10,7 @@ config_dir = case node['platform_family']
              end
 
 pdns_authoritative_config 'server_02' do
-  action :create
+  virtual true
   run_user 'another-pdns'
   run_group 'another-pdns'
   run_user_home '/var/lib/another-pdns'
@@ -58,10 +50,11 @@ file "#{config_dir}/example.org.zone" do
   mode '0440'
 end
 
-pdns_authoritative_service '' do
-  action [:enable, :start]
+pdns_authoritative_service 'default' do
+  action :restart
 end
 
 pdns_authoritative_service 'server_02' do
-  action [:enable, :start]
+  instance_name 'server_02'
+  action :restart
 end

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -28,9 +28,7 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-pdns_authoritative_install '' do
-  action :install
-end
+pdns_authoritative_install 'default'
 
 pg_backend_package = value_for_platform_family(
   'rhel' => 'pdns-backend-postgresql',
@@ -39,8 +37,7 @@ pg_backend_package = value_for_platform_family(
 
 package pg_backend_package
 
-pdns_authoritative_config '' do
-  action :create
+pdns_authoritative_config 'default' do
   launch ['gpgsql']
   variables(
     gpgsql_host: '127.0.0.1',
@@ -49,10 +46,10 @@ pdns_authoritative_config '' do
     gpgsql_dbname: 'pdns',
     gpgsql_password: 'wadus'
   )
-  notifies :restart, 'pdns_authoritative_service[]'
+  notifies :restart, 'pdns_authoritative_service[default]'
 end
 
-pdns_authoritative_service '' do
+pdns_authoritative_service 'default' do
   action [:enable, :start]
 end
 

--- a/test/cookbooks/pdns_test/recipes/recursor_install_multi.rb
+++ b/test/cookbooks/pdns_test/recipes/recursor_install_multi.rb
@@ -1,17 +1,9 @@
-pdns_recursor_install '' do
-  action :install
-end
+pdns_recursor_install 'default'
 
-pdns_recursor_config '' do
-  action :create
-end
-
-pdns_recursor_install 'server_02' do
-  action :install
-end
+pdns_recursor_config 'default'
 
 pdns_recursor_config 'server_02' do
-  action :create
+  virtual true
   run_user 'another-pdns'
   run_group 'another-pdns'
   run_user_home '/var/lib/another-pdns'
@@ -20,10 +12,11 @@ pdns_recursor_config 'server_02' do
   )
 end
 
-pdns_recursor_service '' do
+pdns_recursor_service 'default' do
   action [:enable, :start]
 end
 
 pdns_recursor_service 'server_02' do
+  virtual true
   action [:enable, :start]
 end

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -47,7 +47,7 @@ describe command('dig -p 54 @127.0.0.1 dnsimple.com') do
 end
 
 ## Regression test for https://github.com/dnsimple/chef-pdns/issues/89
-describe command('rec_control --config-name=server_02 --socket-dir=/var/run/server_02 reload-zones') do
+describe command('rec_control --config-name=server_02 reload-zones') do
   its('stdout') { should match('ok') }
   its('stdout') { should_not match('unable to parse configuration file') }
   its('stdout') { should_not match('Encountered error reloading zones, keeping original data: Unable to re-parse configuration file') }


### PR DESCRIPTION
This is the other half of #102 to cover recursor installs

A major source of confusion in this cookbook resolves around the capability of PowerDNS to support virtual instances. It has been 'implied' around the instance_name property, but it is very confusing and not very explicit. Adding a new boolean property called 'virtual' lets us explicitly mark these instances so that the proper service and configurations can be created that PowerDNS expects versus doing weird things around sniffing if instance_name is defined a certain way or not.