### PR TITLE
Add backends option to Authoritative Installation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Installs PowerDNS authoritative server 4.1.x series using PowerDNS official repo
 | series        | String      | '41'           |
 | debug         | true, false | false          |
 | allow_upgrade | true, false | false          |
+| backends      | Array       | nil            |
+
+**Note:** When specifying the backends, the name of the backend must match the repository package. For example, in Debian systems the Postgresql backend is actually named `pgsql` while on RHEL systems it is `postgresql`. Consider using the `value_for_platform` if you are installing on multiple platforms. There is an example of this technique in the test folder cookbook recipe.
 
 #### Usage examples
 
@@ -131,6 +134,15 @@ Install and upgrade to the latest 4.0.x PowerDNS Authoritative Server release
 pdns_authoritative_install 'server_01' do
   series '40'
   allow_upgrade true
+end
+```
+
+Install the latest 4.1.x series PowerDNS Authoritative Server with the MySQL and Lua backends
+
+```ruby
+pdns_authoritative_install 'server_01' do
+  series '41'
+  backends ['mysql', 'lua']
 end
 ```
 

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -29,6 +29,7 @@ property :version, String
 property :series, String, default: '41'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
+property :backends, Array
 
 action :install do
   apt_repository 'powerdns-authoritative' do
@@ -43,6 +44,15 @@ action :install do
   apt_preference 'pdns-*' do
     pin          'origin repo.powerdns.com'
     pin_priority '600'
+  end
+
+  if new_resource.backends
+    new_resource.backends.each do |backend|
+      apt_package "pdns-backend-#{backend}" do
+        action :upgrade if new_resource.allow_upgrade
+        version new_resource.version
+      end
+    end
   end
 
   apt_package 'pdns-server' do

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -25,6 +25,7 @@ property :version, String
 property :series, String, default: '41'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
+property :backends, Array
 
 action :install do
   yum_package 'epel-release' do
@@ -48,6 +49,15 @@ action :install do
     includepkgs 'pdns*'
     action :create
     not_if { new_resource.debug }
+  end
+
+  if new_resource.backends
+    new_resource.backends.each do |backend|
+      yum_package "pdns-backend-#{backend}" do
+        action :upgrade if new_resource.allow_upgrade
+        version new_resource.version
+      end
+    end
   end
 
   yum_package 'pdns' do

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -28,14 +28,14 @@ execute 'psql -d pdns < /var/tmp/schema_postgres.sql' do
   not_if 'psql -t -d pdns -c "select \'public.domains\'::regclass;"', user: 'postgres'
 end
 
-pdns_authoritative_install 'default'
-
 pg_backend_package = value_for_platform_family(
-  'rhel' => 'pdns-backend-postgresql',
-  'debian' => 'pdns-backend-pgsql'
+  'rhel' => 'postgresql',
+  'debian' => 'pgsql'
 )
 
-package pg_backend_package
+pdns_authoritative_install 'default' do
+  backends [pg_backend_package]
+end
 
 pdns_authoritative_config 'default' do
   launch ['gpgsql']

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -34,7 +34,14 @@ pg_backend_package = value_for_platform_family(
 )
 
 pdns_authoritative_install 'default' do
+  series '40'
   backends [pg_backend_package]
+end
+
+pdns_authoritative_install 'default_upgrade' do
+  series '41'
+  backends [pg_backend_package]
+  allow_upgrade true
 end
 
 pdns_authoritative_config 'default' do


### PR DESCRIPTION
This PR should close #104 to add support for backend installation _before_ the server install in the event of upgrades or new installations. Kind of a chicken and egg problem in that the backend _must_ exist _and_ match the version being installed or upgraded to.