### PR TITLE
Switch default to 4.5.x Drop testing for Debian 9 since upstream has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
         os:
           - 'centos-7'
           - 'centos-8'
+          - 'debian-11'
           - 'debian-10'
-          - 'debian-9'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
         suite:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -25,17 +25,17 @@ platforms:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
+  - name: debian-10
     driver:
-      image: dokken/debian-9
+      image: dokken/debian-10
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install dnsutils -y
 
-  - name: debian-10
+  - name: debian-11
     driver:
-      image: dokken/debian-10
+      image: dokken/debian-11
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -26,7 +26,7 @@ provides :pdns_authoritative_install, platform: 'debian' do |node|
 end
 
 property :version, String
-property :series, String, default: '44'
+property :series, String, default: '45'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 property :backends, Array

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -22,7 +22,7 @@ provides :pdns_authoritative_install, platform_family: 'rhel' do |node|
 end
 
 property :version, String
-property :series, String, default: '44'
+property :series, String, default: '45'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 property :backends, Array

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -25,7 +25,7 @@ provides :pdns_recursor_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 9
 end
 
-property :series, String, default: '44'
+property :series, String, default: '45'
 property :version, String
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -22,7 +22,7 @@ provides :pdns_recursor_install, platform_family: 'rhel' do |node|
 end
 
 property :version, String
-property :series, String, default: '44'
+property :series, String, default: '45'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -6,7 +6,7 @@ execute 'disble postgresql dnf module' do
 end
 
 postgresql_server_install 'default' do
-  version '10'
+  version '13'
   action [:install, :create]
 end
 
@@ -41,12 +41,12 @@ pg_backend_package = value_for_platform_family(
 include_recipe 'pdns_test::disable_systemd_resolved'
 
 pdns_authoritative_install 'default' do
-  series '43'
+  series '44'
   backends [pg_backend_package]
 end
 
 pdns_authoritative_install 'default_upgrade' do
-  series '44'
+  series '45'
   backends [pg_backend_package]
   allow_upgrade true
 end

--- a/test/integration/authoritative-multi/default_spec.rb
+++ b/test/integration/authoritative-multi/default_spec.rb
@@ -31,9 +31,9 @@ describe processes(Regexp.new(/pdns_server\s(?=--config-name=server_02)/)) do
 end
 
 describe command('dig -p 53 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.4\.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.5\.\d/) }
 end
 
 describe command('dig -p 54 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.4\.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.5\.\d/) }
 end

--- a/test/integration/authoritative-postgres/default_spec.rb
+++ b/test/integration/authoritative-postgres/default_spec.rb
@@ -26,7 +26,7 @@ describe processes('pdns_server') do
 end
 
 describe command('dig chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.4.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.5.\d/) }
 end
 
 describe command('dig @127.0.0.1 smoke.example.org') do

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -31,11 +31,11 @@ describe processes(Regexp.new(/pdns_recursor --config-name=server_02/)) do
 end
 
 describe command('dig -p 53 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.4\.\d/)) }
+  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.5\.\d/)) }
 end
 
 describe command('dig -p 54 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.4\.\d/)) }
+  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.5\.\d/)) }
 end
 
 describe command('dig -p 53 @127.0.0.1 dnsimple.com') do


### PR DESCRIPTION
for those pinned this is a no-op. Otherwise, this can cause upgrades
The cookbook should still work for Debian 9 with older series than 4.5