### PR TITLE
update ci deps and jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,3 @@ updates:
       - dependencies
     reviewers:
       - "dnsimple/sip"
-      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels:
+      - task
+      - dependencies
+    reviewers:
+      - "dnsimple/sip"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
       - dependencies
     reviewers:
       - "dnsimple/sip"
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Setup Private Cookbook Access
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Run Cookstyle
@@ -45,10 +41,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Setup Private Cookbook Access
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Rspec
@@ -89,17 +81,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Run Test Kitchen
         uses: actionshub/test-kitchen@main
         env:
           CHEF_LICENSE: accept-no-persist
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-          DOCKER_HUB_USER: dnsimpleops
           KITCHEN_LOCAL_YAML: kitchen.yml
         with:
           suite: ${{ matrix.suite }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,31 @@
 ---
 name: ci
 
-"on":
+on:
   pull_request:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  delivery:
+  cookstyle:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Setup Private Cookbook Access
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Run Cookstyle
         run: chef exec rake cookstyle
-        env:
-          CHEF_LICENSE: accept-no-persist
-      - name: Run Specs
-        run: chef exec rake spec
         env:
           CHEF_LICENSE: accept-no-persist
 
@@ -28,23 +33,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v2.0.0
+        uses: nosborn/github-action-markdown-cli@v3.2.0
         with:
           files: .
           config_file: ".markdownlint.yaml"
+
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Setup Private Cookbook Access
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Install Chef Workstation
+        uses: actionshub/chef-install@main
+      - name: Rspec
+        run: chef exec rake spec
+        env:
+          CHEF_LICENSE: accept-no-persist
 
   yamllint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run YAML Lint
         uses: actionshub/yamllint@main
 
   integration:
-    needs: [delivery, markdownlint-cli, yamllint]
+    needs:
+      - cookstyle
+      - markdownlint-cli
+      - rspec
+      - yamllint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -63,13 +88,18 @@ jobs:
     continue-on-error: ${{ matrix.os == 'centos-8' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
       - name: Run Test Kitchen
         uses: actionshub/test-kitchen@main
         env:
           CHEF_LICENSE: accept-no-persist
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+          DOCKER_HUB_USER: dnsimpleops
           KITCHEN_LOCAL_YAML: kitchen.yml
         with:
           suite: ${{ matrix.suite }}
@@ -79,5 +109,4 @@ jobs:
         run: |
             set -x
             sudo journalctl -l --since today
-            KITCHEN_LOCAL_YAML=kitchen.yml /usr/bin/kitchen exec \
-            ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
+            KITCHEN_LOCAL_YAML=kitchen.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
+      - name: Install Spec gems
+        run: chef gem install deepsort
+        env:
+          CHEF_LICENSE: accept-no-persist
       - name: Rspec
         run: chef exec rake spec
         env:
@@ -83,6 +87,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef Workstation
         uses: actionshub/chef-install@main
+      - name: Install Spec gems
+        run: chef gem install deepsort
+        env:
+          CHEF_LICENSE: accept-no-persist
       - name: Run Test Kitchen
         uses: actionshub/test-kitchen@main
         env:

--- a/.yamllint
+++ b/.yamllint
@@ -5,3 +5,6 @@ rules:
   line-length:
     max: 256
     level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ When submitting an issue, please check the [Issues](https://github.com/dnsimple/
 In order to maintain a high standard of compatibility and consistency for the consumers of our cookbook we like to make sure all pull requests meet the following criteria:
 
 1. **Tests:** To ensure high quality code and protect against regressions in the future we require all changes have ample test coverage. This does not mean 100% coverage or even specific types of coverage. See the TESTING.md file for details on how to run the test suite.
-2. **Passing Continuous Integration (CI):** Speaking of tests, the contributed code must pass our full suite of tests on [Travis-CI](https://travis-ci.com/github/dnsimple/chef-pdns) and show a green indicator meaning the latest build passes. If for some reason the build is failing before your pull request, please raise the issue in the pull request so we may address it.
+2. **Passing Continuous Integration (CI):** Speaking of tests, the contributed code must pass our full suite of tests on [GitHub](https://github.com/dnsimple/chef-pdns/actions) and show a green indicator meaning the latest build passes. If for some reason the build is failing before your pull request, please raise the issue in the pull request so we may address it.
 
 ### Code Review Process
 
@@ -36,5 +36,4 @@ Once you open a pull request, cookbook maintainers will review your code using t
 * **DONT** modify the `CHANGELOG.md` in your pull request as well. The maintainers will auto-generate this before a new release.
 * **DO** remember that humans are handling your contributions so please be nice and polite when discussing anything in your pull request.
 
-[security page]: https://dnsimple.com/security
-[Travis-CI]: https://travis-ci.com
+[DNSimple Security Page](https://dnsimple.com/security)


### PR DESCRIPTION
- Updates `ci.yml` jobs to replace 'delivery' with 'cookstyle' and 'rspec'
- Bump GH actions dependencies
- Ignore truthy in `ci.yml` for GH actions configuration
- Fix for `mdl` link in CONTRIBUTING