### PR TITLE
Update supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
       matrix:
         os:
           - 'centos-stream-9'
-          - 'centos-stream-10'
           - 'debian-11'
           - 'debian-12'
           - 'ubuntu-2204'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'centos-7'
-          - 'centos-8'
-          - 'debian-10'
+          - 'centos-stream-9'
           - 'debian-11'
-          - 'ubuntu-2004'
+          - 'debian-12'
           - 'ubuntu-2204'
+          - 'ubuntu-2404'
         suite:
           - 'authoritative-multi'
           - 'authoritative-postgres'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         os:
           - 'centos-stream-9'
+          - 'centos-stream-10'
           - 'debian-11'
           - 'debian-12'
           - 'ubuntu-2204'

--- a/README.md
+++ b/README.md
@@ -132,34 +132,34 @@ Installs PowerDNS authoritative server 4.7.x series using PowerDNS official repo
 
 #### pdns_authoritative_install Usage examples
 
-Install the latest 4.8.x series PowerDNS Authoritative Server
+Install the latest 4.9.x series PowerDNS Authoritative Server
 
 ```ruby
 pdns_authoritative_install 'server_01'
 ```
 
-Install the latest 4.7.x series PowerDNS Authoritative Server
-
-```ruby
-pdns_authoritative_install 'server_01' do
-  series '47'
-end
-```
-
-Install and upgrade to the latest 4.8.x PowerDNS Authoritative Server release
-
-```ruby
-pdns_authoritative_install 'server_01' do
-  series '47'
-  allow_upgrade true
-end
-```
-
-Install the latest 4.8.x series PowerDNS Authoritative Server with the MySQL and Lua backends
+Install the latest 4.8.x series PowerDNS Authoritative Server
 
 ```ruby
 pdns_authoritative_install 'server_01' do
   series '48'
+end
+```
+
+Install and upgrade to the latest 4.9.x PowerDNS Authoritative Server release
+
+```ruby
+pdns_authoritative_install 'server_01' do
+  series '49'
+  allow_upgrade true
+end
+```
+
+Install the latest 4.9.x series PowerDNS Authoritative Server with the MySQL and Lua backends
+
+```ruby
+pdns_authoritative_install 'server_01' do
+  series '49'
   backends ['mysql', 'lua']
 end
 ```
@@ -259,25 +259,25 @@ Installs PowerDNS recursor 4.8.x series using PowerDNS official repository in th
 
 #### pdns_recursor_install Usage examples
 
-Install the latest 4.8.x release PowerDNS recursor
+Install the latest 5.0.x release PowerDNS recursor
 
 ```ruby
-pdns_recursor_install 'latest_4_8_x_recursor'
+pdns_recursor_install 'latest_5_0_x_recursor'
 ```
 
-Install the latest 4.7.x release PowerDNS recursor
+Install the latest 4.9.x release PowerDNS recursor
 
 ```ruby
 pdns_recursor_install 'my_recursor' do
-  series '47'
+  series '49'
 end
 ```
 
-Install and upgrade to the latest 4.8.x PowerDNS recursor release
+Install and upgrade to the latest 5.0.x PowerDNS recursor release
 
 ```ruby
 pdns_recursor_install 'my_recursor' do
-  series '47'
+  series '50'
   allow_upgrade true
 end
 ```
@@ -374,7 +374,7 @@ There is an specific file for testing guidelines on this cookbook: TESTING.md
 
 ## License
 
-Copyright (c) 2010-2014, Chef Software, Inc
-Copyright (c) 2014-2023, DNSimple Corporation
+Copyright (c) 2010-2025, Chef Software, Inc
+Copyright (c) 2014-2025, DNSimple Corporation
 
 Licensed under the Apache License, Version 2.0.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,14 +15,9 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-7
+  - name: centos-stream-9
     driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-8
-    driver:
-      image: dokken/centos-8
+      image: centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: debian-10
@@ -41,9 +36,9 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install dnsutils -y
 
-  - name: ubuntu-20.04
+  - name: debian-12
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/debian-12
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -52,6 +47,14 @@ platforms:
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install dnsutils -y
+
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,16 +17,13 @@ verifier:
 platforms:
   - name: centos-stream-9
     driver:
-      image: centos-stream-9
+      image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-10
+  - name: centos-stream-10
     driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install dnsutils -y
+      image: dokken/centos-stream-10
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: debian-11
     driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,11 +20,6 @@ platforms:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-stream-10
-    driver:
-      image: dokken/centos-stream-10
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: debian-11
     driver:
       image: dokken/debian-11

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ issues_url       'https://github.com/dnsimple/chef-pdns/issues'
 
 chef_version '>= 15'
 
-supports 'ubuntu', '>= 20.04'
-supports 'debian', '>= 9.0'
+supports 'ubuntu', '>= 22.04'
+supports 'debian', '>= 11.0'
 supports 'centos', '>= 7.0'
-supports 'redhat', '>= 7.0'

--- a/resources/authoritative_install_debian.rb
+++ b/resources/authoritative_install_debian.rb
@@ -27,7 +27,7 @@ provides :pdns_authoritative_install, platform: 'debian' do |node|
 end
 
 property :version, String
-property :series, String, default: '48'
+property :series, String, default: '49'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 property :backends, Array
@@ -36,7 +36,6 @@ action :install do
   apt_repository 'powerdns-authoritative' do
     uri "http://repo.powerdns.com/#{node['platform']}"
     distribution "#{node['lsb']['codename']}-auth-#{new_resource.series}"
-    arch 'amd64'
     components ['main']
     key 'powerdns.asc'
     cookbook 'pdns'

--- a/resources/authoritative_install_rhel.rb
+++ b/resources/authoritative_install_rhel.rb
@@ -23,7 +23,7 @@ unified_mode true do |node|
 end
 
 property :version, String
-property :series, String, default: '48'
+property :series, String, default: '49'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 property :backends, Array

--- a/resources/recursor_install_debian.rb
+++ b/resources/recursor_install_debian.rb
@@ -26,7 +26,7 @@ provides :pdns_recursor_install, platform: 'debian' do |node|
   node['platform_version'].to_i >= 9
 end
 
-property :series, String, default: '48'
+property :series, String, default: '50'
 property :version, String
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
@@ -35,7 +35,6 @@ action :install do
   apt_repository 'powerdns-recursor' do
     uri "http://repo.powerdns.com/#{node['platform']}"
     distribution "#{node['lsb']['codename']}-rec-#{new_resource.series}"
-    arch 'amd64'
     components ['main']
     key 'powerdns.asc'
     cookbook 'pdns'

--- a/resources/recursor_install_rhel.rb
+++ b/resources/recursor_install_rhel.rb
@@ -23,7 +23,7 @@ unified_mode true do |node|
 end
 
 property :version, String
-property :series, String, default: '48'
+property :series, String, default: '50'
 property :debug, [true, false], default: false
 property :allow_upgrade, [true, false], default: false
 

--- a/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
+++ b/test/cookbooks/pdns_test/recipes/authoritative_install_single_postgres.rb
@@ -45,7 +45,7 @@ pg_backend_package = value_for_platform_family(
 include_recipe 'pdns_test::disable_systemd_resolved'
 
 pdns_authoritative_install 'default' do
-  series '48'
+  series '49'
   backends [pg_backend_package]
   allow_upgrade true
 end

--- a/test/integration/authoritative-multi/default_spec.rb
+++ b/test/integration/authoritative-multi/default_spec.rb
@@ -27,9 +27,9 @@ describe group(default_authoritative_run_user) do
 end
 
 describe command('dig -p 53 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.8\.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.9\.\d/) }
 end
 
 describe command('dig -p 54 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.8\.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.9\.\d/) }
 end

--- a/test/integration/authoritative-postgres/default_spec.rb
+++ b/test/integration/authoritative-postgres/default_spec.rb
@@ -26,7 +26,7 @@ describe processes('pdns_server') do
 end
 
 describe command('dig chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.8.\d/) }
+  its('stdout.chomp') { should match(/"PowerDNS Authoritative Server 4\.9.\d/) }
 end
 
 describe command('dig @127.0.0.1 smoke.example.org') do

--- a/test/integration/recursor-multi/default_spec.rb
+++ b/test/integration/recursor-multi/default_spec.rb
@@ -27,11 +27,11 @@ describe group(default_recursor_run_user) do
 end
 
 describe command('dig -p 53 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.8\.\d/)) }
+  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 5\.0\.\d/)) }
 end
 
 describe command('dig -p 54 chaos txt version.bind @127.0.0.1 +short') do
-  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 4\.8\.\d/)) }
+  its('stdout.chomp') { should match(Regexp.new(/"PowerDNS Recursor 5\.0\.\d/)) }
 end
 
 describe command('dig -p 53 @127.0.0.1 dnsimple.com') do


### PR DESCRIPTION
Update supported platforms and actions matrix

- Updated platforms to align with https://repo.powerdns.com/
- Authoritative defaults to v49
- Recursor defaults to v50

## :shipit: Deploy Steps:

- [x] Merge and pull latest

## :shipit: Verification Steps

- [x] Verify CI is passing